### PR TITLE
Accessibility improvement in copy

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -96,8 +96,8 @@
         <a class="white" href="mailto:listserv@listserv.gsa.gov?subject=Join%20Code.gov%20List&body=SUBSCRIBE%20CODE">JOIN THE LISTSERV</a>
         <a href="https://sourcecode.cio.gov/">READ THE POLICY</a>
       </div>
-      <p>This is an open source project of the U.S. Government.  You can find the code <a href="https://github.com/presidential-innovation-fellows/code-gov-web">here</a>.</p>
-    </div>
+      <p>This is an open source project of the U.S. Government. Check out <a href="https://github.com/presidential-innovation-fellows/code-gov-web">the code for this site</a>.</p>
+      </div>
 
     <!-- Google Tag Manager -->
     <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-M9L9Q5"


### PR DESCRIPTION
Hi hi!

Linking just the word "here" is hard for folks using a screenreader to understand -- if you're skipping down the page and just reading the link text to decide what to click on, you would just hear "here" instead of "the code for this site."

Hope this helps!