### PR TITLE
easy link to discuss new source code policy area

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -95,6 +95,7 @@
       <div class="buttons">
         <a class="white" href="mailto:listserv@listserv.gsa.gov?subject=Join%20Code.gov%20List&body=SUBSCRIBE%20CODE">JOIN THE LISTSERV</a>
         <a href="https://sourcecode.cio.gov/">READ THE POLICY</a>
+        <a href="https://github.com/whitehouse/source-code-policy/issues/">DISCUSS THE POLICY</a>
       </div>
       <p>This is an open source project of the U.S. Government. Check out <a href="https://github.com/presidential-innovation-fellows/code-gov-web">the code for this site</a>.</p>
     </div>


### PR DESCRIPTION
clarifies/confirms where visitors should go to discuss the new policy, since they might think the source-code-policy repo is just for discussion of the draft doc. It would be helpful to channel discussion toward one repo rather than splitting across source-code-policy repo and code-gov-web repo.
