### PR TITLE
Add email validation

### DIFF
--- a/dist/js/confirmation.js
+++ b/dist/js/confirmation.js
@@ -2,9 +2,17 @@
 var submitted=false; 
 
 function showConfirmation(){
-  submitted=true;
-  document.getElementById("confirmation").innerHTML='Thanks for joining the code.gov mailing list, '+document.getElementById("mce-EMAIL").value+'!'; 
-  
-  document.getElementById("mce-EMAIL").value=' ';
+  var emailField  = document.getElementById('mce-EMAIL');
+  var confirmationEl = document.getElementById("confirmation");
+
+  if(emailField.validity && !emailField.validity.valid) {
+    confirmationEl.innerHTML='Please enter a valid email.';
+  }
+  else {
+    submitted=true;
+    confirmationEl.innerHTML='Thanks for joining the code.gov mailing list, ' + emailField.value + '!';
+
+    emailField.value=' ';
+  }
 }
         


### PR DESCRIPTION
Thought I'd make sure to add some validation on the submitted email.

works on > IE10 and Chrome, Safari, Firefox
(source: https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)

fails gracefully < IE9