### PR TITLE
Correct the key projects to project

### DIFF
--- a/_draft_content/schema/code.json
+++ b/_draft_content/schema/code.json
@@ -1,7 +1,7 @@
 {
     "agency": "DOABC",
     "organization": "XYZ Department",
-    "projects": [
+    "project": [
         {
             "name": "mygov",
             "description": "A Platform for Conecting People and Government",


### PR DESCRIPTION
The 1.0 specification has the key as singular, but this example file had the name as plural
