### PR TITLE
Use Hash for Routes

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,6 +5,7 @@ import { HttpModule } from '@angular/http';
 import { RouterModule } from '@angular/router';
 import { removeNgStyles, createNewHosts } from '@angularclass/hmr';
 import { AuthHttp, AuthConfig, AUTH_PROVIDERS, provideAuth} from 'angular2-jwt';
+import { HashLocationStrategy, LocationStrategy } from '@angular/common';
 
 /*
  * Platform and Environment providers/directives/pipes
@@ -32,7 +33,7 @@ const APP_PROVIDERS = [
     FormsModule,
     ReactiveFormsModule,
     HttpModule,
-    RouterModule.forRoot(ROUTES, { useHash: false })
+    RouterModule.forRoot(ROUTES, { useHash: true })
   ],
   declarations: [
     AppComponent,
@@ -42,6 +43,7 @@ const APP_PROVIDERS = [
   ],
   providers: [ // expose our Services and Providers into Angular's dependency injection
     ENV_PROVIDERS,
+    {provide: LocationStrategy, useClass: HashLocationStrategy},
     APP_PROVIDERS
   ],
   bootstrap: [ AppComponent ]

--- a/src/index.html
+++ b/src/index.html
@@ -17,7 +17,6 @@
   <!-- base url -->
   <base href="<%= webpackConfig.metadata.baseUrl %>">
 
-
 </head>
 
 <body>


### PR DESCRIPTION
Adds the Hash back to the URLs to handle routes. For the foreseable future, this is the only solution to host on Federalist and enable visiting pages.

* Enable Hash in Routes