### PR TITLE
Update paths for node and bower directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,8 @@ Icon?
 Thumbs.db
 
 # Node Files #
-/node_modules
-/bower_components
+node_modules/
+bower_components/
 npm-debug.log
 
 # Webpack Files #


### PR DESCRIPTION
* Appending a forward-slash at the end denotes them as directories
* Removing the forward slash at the start of the path allows the directories to be ignored no matter where they are in the repo, helpful as the application is a work in progress and at the very least bower_components/ may move