### PR TITLE
Update package.json info to reflect code-gov-web

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "angular2-webpack-starter",
-  "version": "5.0.5",
-  "description": "An Angular 2 Webpack Starter kit featuring Angular 2 (Router, Http, Forms, Services, Tests, E2E, Coverage), Karma, Protractor, Jasmine, Istanbul, TypeScript, and Webpack by AngularClass",
+  "name": "code-gov-web",
+  "version": "0.0.0",
+  "description": "Code.gov is a website promoting good practices in code development, collaboration, and reuse across the U.S.  Government. Code.gov will provide tools and guidance to help agencies implement the [Federal Source Code Policy](https://sourcecode.cio.gov). It will include an inventory of the government's custom code to promote reuse between agencies and will provide tools to help government and the public collaborate on open source projects.",
   "keywords": [
     "angular2",
     "webpack",
     "typescript"
   ],
   "author": "Patrick Stapleton <patrick@angularclass.com>",
-  "homepage": "https://github.com/angularclass/angular2-webpack-starter",
+  "homepage": "https://github.com/presidential-innovation-fellows/code-gov-web",
   "license": "MIT",
   "scripts": {
     "rimraf": "rimraf",
@@ -150,10 +150,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/angularclass/angular2-webpack-starter.git"
+    "url": "https://github.com/presidential-innovation-fellows/code-gov-web.git"
   },
   "bugs": {
-    "url": "https://github.com/angularclass/angular2-webpack-starter/issues"
+    "url": "https://github.com/presidential-innovation-fellows/code-gov-web/issues"
   },
   "engines": {
     "node": ">= 4.2.1",


### PR DESCRIPTION
Update project name and description. As well as the links for homepage, git repo, and issues.

Also, since this would be the first time to change the project's name to code-gov-web, I figured we'd want to update the version number so people didn't think we were further along than we are.