### PR TITLE
Update Homepage Content and Use Conservative Colors For Launch

### DIFF
--- a/src/app/components/app/app.style.scss
+++ b/src/app/components/app/app.style.scss
@@ -11,7 +11,7 @@
   }
 
   .app-navigation {
-    background-color: $brand-purple;
+    background-color: darken($color-primary, 10);
     font-size: 0.9em;
 
     @include media($small-screen) {
@@ -20,6 +20,10 @@
 
     a {
       color: lighten($brand-blue-gray, 50);
+
+      &:focus {
+        box-shadow: 0 0 3px rgba($color-white, 0.25), 0 0 7px rgba($color-white, 0.25);
+      }
 
       &:hover {
         color: $color-white;
@@ -151,7 +155,7 @@
 
   li {
     display: inline-block;
-    margin-right: 0.5em;
+    margin-right: 1em;
   }
 }
 

--- a/src/app/components/app/app.template.html
+++ b/src/app/components/app/app.template.html
@@ -53,7 +53,7 @@
                 <a href="https://18f.gsa.gov/linking-policy/" target="_blank">Linking Policy</a>
               </li>
               <li>
-                <a href="https://github.com/presidential-innovation-fellows/code-gov-web" target="_blank">View on GitHub</a>
+                <a href="https://github.com/presidential-innovation-fellows/code-gov-web" target="_blank">Visit Project Page</a>
               </li>
             </ul>
           </nav>

--- a/src/app/components/home/banner-art/banner-art.style.scss
+++ b/src/app/components/home/banner-art/banner-art.style.scss
@@ -32,6 +32,15 @@
     width: 45em;
   }
 
+  a {
+    color: lighten($brand-teal, 12);
+    text-decoration: none;
+
+    &:focus {
+      box-shadow: 0 0 3px rgba($color-white, 0.25), 0 0 7px rgba($color-white, 0.25);
+    }
+  }
+
   p {
     color: lighten($brand-blue-gray, 50);
     font-size: 0.85em;
@@ -59,9 +68,5 @@
 
   .dolla {
     margin-right: 0.5em;
-  }
-
-  .teal {
-    color: $brand-teal;
   }
 }

--- a/src/app/components/home/banner-art/banner-art.template.html
+++ b/src/app/components/home/banner-art/banner-art.template.html
@@ -2,11 +2,11 @@
   <div class="content">
     <p>
       <span class="dolla">$</span>
-      Want to help make <span class="teal">Code.gov</span> more awesome?
+      Want to contribute to <a href="./">Code.gov</a>?
     </p>
     <p class="second-line">
       <span class="dolla">$</span>
-      git clone git@github.com:presidential-innovation-fellows/code-gov-web.git
+      Visit our <a href="https://github.com/presidential-innovation-fellows/code-gov-web" target="_blank">project page</a> or git clone git@github.com:presidential-innovation-fellows/code-gov-web.git
       <span class="cursor">&#x275a;</span>
     </p>
   </div>

--- a/src/app/components/home/home.style.scss
+++ b/src/app/components/home/home.style.scss
@@ -95,7 +95,7 @@ body {
 }
 
 .banner {
-  background-color: $brand-purple;
+  background-color: darken($color-primary, 10);
   background-size: cover;
   background-repeat: no-repeat;
   padding: 2em 0 8em;
@@ -151,7 +151,7 @@ body {
 }
 
 .banner-container {
-  background-color: $brand-purple;
+  background-color: darken($color-primary, 10);
   margin: 0 auto;
   max-width: 30em;
   text-align: center;


### PR DESCRIPTION
Updates the Homepage content to generalize links to our GitHub project page and makes the colors more conservative for launch day.

* Update links to our GitHub page to use more generalized text
* Update banner color to be more conservative for launch day