### PR TITLE
Improve Content Formatting and Styles for Policy Guide

### DIFF
--- a/src/app/components/policy-guide/docs/capacity/capacity-introduction/capacity-introduction.template.html
+++ b/src/app/components/policy-guide/docs/capacity/capacity-introduction/capacity-introduction.template.html
@@ -1,15 +1,21 @@
 <h1>Building Your Agency's Open Source Practice</h1>
-<p><a href="https://policy.cio.gov/source-code/implementation/">Section 7.1</a> of the Source Code Policy discusses roles and responsibilities within agencies in meeting the overall requirements of the policy. Regarding the Open Source Pilot Program, it also notes that &ldquo;<em>agencies should strengthen internal capacity to efficiently and securely deliver OSS as part of regular operations.&rdquo; </em></p>
+<p><a href="https://policy.cio.gov/source-code/implementation/">Section 7.1</a> of the Source Code Policy discusses roles and responsibilities within agencies in meeting the overall requirements of the policy. Regarding the Open Source Pilot Program, it also notes that:</p>
+<blockquote>
+  <p>
+    Agencies should strengthen internal capacity to efficiently and securely deliver OSS as part of regular operations.
+  </p>
+</blockquote>
 <p>Whether it is with a focus on building capacity in software acquisition, development, or both, agencies will benefit from developing staff expertise in a number of areas. In some cases, agencies may also want to build technical capacity.</p>
 <p>The open source practice for the U.S. government is expected to rapidly evolve and become more sophisticated over the next several years, so the advice provided here will also evolve.</p>
 <h2>Engaged and supportive agency leadership</h2>
 <p>Agencies and teams that have been most successful in establishing their open source practice have benefited from engaged and supportive agency leadership who have helped teams navigate key legal, security, and operational issues. Strong engagement from the agency CIO and other leadership can have the effect of convening the necessary stakeholders to have a serious conversation. It can also greatly accelerate the establishment of clear, repeatable processes and foundational policy. With this foundation in place, your agency's teams can refine policy and process as they learn together.</p>
 <h2>Open Source is an interdisciplinary practice</h2>
 <p>Section 7.1 of the policy provides a long (and non-exhaustive) list of individuals and teams who have a role in your agency's open source practice:</p>
-<p><em>[..] agency heads must ensure that CIOs and Senior Agency Officials,</em> <em>including CAOs, are positioned with the responsibility and authority necessary to implement the requirements of this policy. As appropriate, Senior Agency Officials should also work with the agency&rsquo;s public affairs staff, open government staff, web manager or digital strategist, program owners, and other leadership to properly identify, publish, and collaborate with communities on their OSS projects.</em></p>
-<p>&nbsp;</p>
+<blockquote>
+  <p>
+    [..] agency heads must ensure that CIOs and Senior Agency Officials,including CAOs, are positioned with the responsibility and authority necessary to implement the requirements of this policy. As appropriate, Senior Agency Officials should also work with the agency&rsquo;s public affairs staff, open government staff, web manager or digital strategist, program owners, and other leadership to properly identify, publish, and collaborate with communities on their OSS projects.
+  </p>
+</blockquote>
 <p>In order to be successful in meeting the requirements of the policy and realize return on its investment in open source, your agency shouldn't treat it as merely a technical or acquisitions issue. Instead, the most successful agencies will approach open source in a similar manner to security and change management - as an essentially interdisciplinary capability that requires deliberate, formal coordination across the organization.</p>
-<p>&nbsp;</p>
 <h2>Consult with peer agencies and share practices</h2>
 <p>In the spirit of open source development, agencies can benefit greatly from adopting each other&rsquo;s approaches to open source generally and even specific language that has been developed with regards to issues like licensing and contract language. Complex topics like security, communications, and even how to run a successful hackathon are ripe for collaboration between agencies to share lessons learned and pool limited resources.</p>
-<p>&nbsp;</p>

--- a/src/app/components/policy-guide/docs/capacity/capacity-resources/capacity-resources.template.html
+++ b/src/app/components/policy-guide/docs/capacity/capacity-resources/capacity-resources.template.html
@@ -1,22 +1,26 @@
 <h1>Tools and Resources</h1>
 <p><a href="https://policy.cio.gov/source-code/implementation/#code-repositories">Section 7.4</a>&nbsp;of the Source Code Policy states:</p>
-<p><em>Accessible, buildable, version-controlled repositories for the storage, discussion, and modification of custom-developed code are critical to both the Government-wide reuse and OSS pilot program sections of this policy. Agencies should utilize existing code repositories and common third-party repository platforms as necessary in order to satisfy the requirements of this policy.</em></p>
+<blockquote>
+  <p>
+    Accessible, buildable, version-controlled repositories for the storage, discussion, and modification of custom-developed code are critical to both the Government-wide reuse and OSS pilot program sections of this policy. Agencies should utilize existing code repositories and common third-party repository platforms as necessary in order to satisfy the requirements of this policy.
+  </p>
+</blockquote>
 <p>Agencies can use the list of tools and resources outlined here to become more fluent in the open source marketplace and best practices inside and outside of government.</p>
-<p><strong>Important: t</strong>he tools and resources outlined here are not mandatory for agency use and are not endorsed by any part of the government. The purpose of this page is to provide broader context for agencies and to provide perspective into the breadth of tools available. Also, this list does not attempt to be exhaustive on any topic; new tools are constantly being developed and practices are constantly evolving.</p>
+<p><strong>Important:</strong> the tools and resources outlined here are not mandatory for agency use and are not endorsed by any part of the government. The purpose of this page is to provide broader context for agencies and to provide perspective into the breadth of tools available. Also, this list does not attempt to be exhaustive on any topic; new tools are constantly being developed and practices are constantly evolving.</p>
 <p>Individuals and companies that want to suggest tools for inclusion here can do so by opening an Issue or creating a Pull Request on the Code.gov repository.</p>
 <h2>Choosing a Version Control System</h2>
 <p>There are a number of version control systems available that may be appropriate to meet your agency's needs. Some questions to ask when selecting such a system are:</p>
 <ul>
 <li>Does the system provide the ability to develop in the open?</li>
 <li>Does your agency need both private and public repositories, and does the system allow seamless integration between the two?</li>
-<li>Is the system interoperable with open source version control standards, such as <a href="https://git-scm.com/">git</a> or <a href="https://www.mercurial-scm.org/">mercurial</a>? Interoperability with an open standard is crucial to your agency's ability to collaborate with other agencies and the open source community and will greatly ease future platform integrations and migrations.</li>
+<li>Is the system interoperable with open source version control standards, such as <a external-link href="https://git-scm.com/">git</a> or <a external-link href="https://www.mercurial-scm.org/">mercurial</a>? Interoperability with an open standard is crucial to your agency's ability to collaborate with other agencies and the open source community and will greatly ease future platform integrations and migrations.</li>
 <li>If your agency plans robust engagement with the open source community it may want to consider the social features of the system beyond version control. Does it provide features that will enhance the ability of your agency to promote and share its code? How vibrant is the existing user community?</li>
 </ul>
 <p>Agencies may want to take a look at the following version control systems based on their functionality and significant adoption by the open source community:</p>
 <ul>
-<li><a href="https://github.com/">Github</a></li>
-<li><a href="https://gitlab.com/">Gitlab</a></li>
-<li><a href="https://bitbucket.org/">Bitbucket</a></li>
+<li><a external-link href="https://github.com/">Github</a></li>
+<li><a external-link href="https://gitlab.com/">Gitlab</a></li>
+<li><a external-link href="https://bitbucket.org/">Bitbucket</a></li>
 </ul>
 <p>&nbsp;</p>
 <h2>Code quality and security</h2>
@@ -29,6 +33,6 @@
 <li>Open Source Listserv (GSA, open to government only)</li>
 <li>Security Listserv (GSA, open to government only)</li>
 <li>Digital Service Listserv (GSA, open to government only)</li>
-<li><a href="https://github.com/government/welcome#readme">Github for Government Community</a> (Not an official Government service.)</li>
+<li><a external-link href="https://github.com/government/welcome#readme">Github for Government Community</a> (Not an official Government service.)</li>
 </ul>
 <p>As a quick reminder, agency staff must comply with applicable law and regulations and should obtain the appropriate agency approvals prior to using any of the tools ans services discussed here.</p>

--- a/src/app/components/policy-guide/docs/capacity/capacity-security/capacity-security.template.html
+++ b/src/app/components/policy-guide/docs/capacity/capacity-security/capacity-security.template.html
@@ -1,6 +1,6 @@
-<h1><a id="Building_Security_into_your_Open_Source_Practice_0"></a>Building Security into your Open Source Practice</h1>
+<h1>Building Security into your Open Source Practice</h1>
 <p>One of the most common concerns raised by agencies related to opening code or developing in the open is information security.  There are a number of specific things that any open source project (governmental or otherwise) can do to protect the security of its sensitive information and its production systems. There are also quite a few myths and misconceptions about security in relation to open source that are worth debunking.</p>
-<h2><a id="Opening_an_existing_codebase_4"></a>Opening an existing codebase</h2>
+<h2>Opening an existing codebase</h2>
 <p>The first thing to understand when considering open sourcing code is that some types of code and data are categorically inappropriate to be made public.  Secure open source practices protect these kinds of content from publication.</p>
 <p>While there are always exceptions and the list isn’t exhaustive, agencies should carefully consider how to limit the risk that the following types of information could be make public as part of an open source offering:</p>
 <ul>
@@ -12,53 +12,58 @@
 <li>content such as inappropriate or offensive language, that could create reputational harm</li>
 </ul>
 <p>^ someone smarter than me has created a list like this. NIST?</p>
-<h2><a id="Developing_in_the_Open_19"></a>Developing in the Open</h2>
+<h2>Developing in the Open</h2>
 <p>Section 5.2.B of the Source Code Policy states that agencies should develop custom code in the open:</p>
-<p><code>Engage in Open Development: Software that is custom-developed for or by agencies should, to the extent possible and appropriate, be developed using open development practices. These practices provide an environment in which OSS can flourish and be repurposed. This principle, as well as the one below for releasing source code, include distributing a minimum viable product as OSS; engaging the public before official release; and drawing upon the public’s knowledge to make improvements to the project.</code>
-At the most basic level, developing in the open means that developers maintain the up-to-date working copy of their code on a publicly accessible repository.</p>
-<h3><a id="For_developers_34"></a>For developers</h3>
+<blockquote>
+  <p>
+    Engage in Open Development: Software that is custom-developed for or by agencies should, to the extent possible and appropriate, be developed using open development practices. These practices provide an environment in which OSS can flourish and be repurposed. This principle, as well as the one below for releasing source code, include distributing a minimum viable product as OSS; engaging the public before official release; and drawing upon the public’s knowledge to make improvements to the project.
+  </p>
+</blockquote>
+<p>
+  At the most basic level, developing in the open means that developers maintain the up-to-date working copy of their code on a publicly accessible repository.
+</p>
+<h3>For developers</h3>
 <ul>
-<li>Make your main codebase open.</li>
-<li>even if a piece of something needs to remain private not everything needs to remain so.</li>
+<li>Make your main codebase open – even if a piece of something needs to remain private not everything needs to remain so.</li>
 <li>Develop modularly</li>
-<li>Don’t bifurcate your project where you don’t have to.
+<li>Don’t bifurcate your project where you don’t have to. i.e.:
 <ul>
-<li>i.e. content</li>
-<li>slows you down</li>
-<li>reviews</li>
-<li>workflow</li>
-<li>design</li>
-<li>versioning</li>
+  <li>Content</li>
+  <li>Slows you down</li>
+  <li>Reviews</li>
+  <li>Workflow</li>
+  <li>Design</li>
+  <li>Versioning</li>
 </ul>
 </li>
 </ul>
-<h3><a id="For_Comms_48"></a>For Comms</h3>
+<h3>For Comms</h3>
 <ul>
 <li>Work with your Comms team
 <ul>
-<li>you can still have your “big reveal”</li>
+<li>You can still have your “big reveal”</li>
 </ul>
 </li>
-<li>set expectations at the outset of a project.
+<li>Set expectations at the outset of a project.
 <ul>
-<li>declare a project “open” in your project charter.</li>
-<li>staff for feedback and engagement with the public throughout the project
+<li>Declare a project “open” in your project charter.</li>
+<li>Staff for feedback and engagement with the public throughout the project
 <ul>
-<li>BENEFITS: early feedback</li>
+<li>BENEFITS: Early feedback</li>
 </ul>
 </li>
 </ul>
 </li>
 </ul>
-<h3><a id="For_Security_56"></a>For Security</h3>
-<pre><code>- if for some reason api keys etc do get published developing in the open makes that less risky by allowing that to happen earlier.
-</code></pre>
-<h2><a id="Organizational_best_practices_60"></a>Organizational best practices</h2>
+<h3>For Security</h3>
+<p>If for some reason api keys etc do get published developing in the open makes that less risky by allowing that to happen earlier.
+</p>
+<h2>Organizational best practices</h2>
 <ul>
 <li>make sure there is a team (real, virtual) in your org who keep track of the open source and monitor and remediate issues, including escalating for security and including process/training improvements. this should be written down and there should be procedures.</li>
 <li></li>
 </ul>
-<h2><a id="Workflow_tips_for_security_64"></a>Workflow tips for security</h2>
+<h2>Workflow tips for security</h2>
 <ul>
 <li>gitignore</li>
 <li>educate your team</li>
@@ -71,27 +76,27 @@ At the most basic level, developing in the open means that developers maintain t
 </ul>
 </li>
 </ul>
-<h1><a id="Myth_Busting_73"></a>Myth Busting</h1>
+<h1>Myth Busting</h1>
 <ul>
-<li>security through obscurity</li>
+<li>Security through obscurity</li>
 <li></li>
 </ul>
-<h1><a id="Case_Studies_77"></a>Case Studies</h1>
+<h1>Case Studies</h1>
 <ul>
-<li>N-CATS pshtt - <a href="https://github.com/dhs-ncats/pshtt">https://github.com/dhs-ncats/pshtt</a></li>
+<li>N-CATS pshtt - <a external-link href="https://github.com/dhs-ncats/pshtt">https://github.com/dhs-ncats/pshtt</a></li>
 </ul>
-<h2><a id="Licensing_86"></a>Licensing</h2>
-<h2><a id="Developing_in_the_open_89"></a>Developing in the open</h2>
+<h2>Licensing</h2>
+<h2>Developing in the open</h2>
 <ul>
-<li>benefits of public feedback</li>
+<li>Benefits of public feedback</li>
 </ul>
-<h2><a id="Technical_practices_94"></a>Technical practices</h2>
+<h2>Technical practices</h2>
 <ul>
 <li>Code versioning</li>
 <li>REQUIRED 7.4 Use common third-party repository platforms</li>
 <li>REQUIRED Integrate OSS practices into your agency’s day-to-day operations (7.1)</li>
 </ul>
-<h2><a id="Communications_102"></a>Communications</h2>
+<h2>Communications</h2>
 <ul>
 <li>you can still have your big reveal
 <ul>
@@ -126,7 +131,7 @@ At the most basic level, developing in the open means that developers maintain t
 <li></li>
 </ul>
 <p>#Github</p>
-<h2><a id="Have_a_set_of_practices_around_using_github_133"></a>Have a set of practices around using github</h2>
+<h2>Have a set of practices around using github</h2>
 <ul>
 <li>low sensitivity
 <ul>
@@ -141,11 +146,11 @@ At the most basic level, developing in the open means that developers maintain t
 <li>have your actual name in there</li>
 <li>if you’re using your work computer - set gitconfig so that it’s using your work email</li>
 </ul>
-<h1><a id="Communications_and_community_engagement_145"></a>Communications and community engagement</h1>
+<h1>Communications and community engagement</h1>
 <p>Community contributions</p>
 <ul>
 <li>it has to be an expectation that comms won’t review every interaction online.</li>
 <li>accounts also associated with personal activities</li>
 </ul>
-<h1><a id="Security_150"></a>Security</h1>
+<h1>Security</h1>
 <p>It is important to integrate strong security practices into your open source development practices to ensure that only code that is appropriate to share publicly is published.  Read here for more on this topic.</p>

--- a/src/app/components/policy-guide/docs/compliance/compliance-inventory-code/compliance-inventory-code.template.html
+++ b/src/app/components/policy-guide/docs/compliance/compliance-inventory-code/compliance-inventory-code.template.html
@@ -1,14 +1,14 @@
-<h1><a id="Populating_your_code_inventory_0"></a>Populating your code inventory</h1>
-<h2><a id="Overview_2"></a>Overview</h2>
+<h1>Populating your code inventory</h1>
+<h2>Overview</h2>
 <p><a href="http://Code.gov">Code.gov</a> will provide a platform to find custom-developed source code intended both for Government-wide reuse and release as open source. <a href="http://Code.gov">Code.gov</a> will compile an aggregate source code inventory from each of the covered federal agencies respective code inventories. In order to balance the need for flexibility to cover range of government code repositories against the  consistency necessary for searching and discovery, we’ve prepared a metadata schema to help catalog each agency’s inventory. And as with all open source projects, the schema itself is a work in progres. As of this writing, we’re released version 1.0 of the metadata schema.</p>
-<p>Agencies should make the “code.json” available in the root folder of their website (e.g., <a href="https://www.gsa.gov/code.json">https://www.gsa.gov/code.json</a>), and <a href="http://code.gov">code.gov</a> will retrieve these JSON files daily (this is a similar approach to Project Open Data - <a href="http://Data.gov">Data.gov</a>).</p>
-<h2><a id="Schema_Specification_7"></a>Schema Specification</h2>
-<p>Each covered agency should prepare an inventory of its custom-developed source code as described in the Metadata Specification </p>
-<h2><a id="How_to_build_your_agencys_code_inventory_10"></a>How to build your agency’s code inventory</h2>
-<h3><a id="Step_1_Reach_out_to_bureaus_and_offices_11"></a>Step 1. Reach out to bureaus and offices</h3>
+<p>Agencies should make the “code.json” available in the root folder of their website (e.g., <a href="https://www.gsa.gov/code.json">https://www.gsa.gov/code.json</a>), and <a href="http://code.gov">Code.gov</a> will retrieve these JSON files daily (this is a similar approach to Project Open Data - <a href="http://Data.gov">Data.gov</a>).</p>
+<h2>Schema Specification</h2>
+<p>Each covered agency should prepare an inventory of its custom-developed source code as described in Section 05: <a href="https://github.com/presidential-innovation-fellows/code-gov-web/blob/master/_draft_content/02_compliance/05-metadata-schema-definition.md">https://github.com/presidential-innovation-fellows/code-gov-web/blob/master/_draft_content/02_compliance/05-metadata-schema-definition.md</a></p>
+<h2>How to build your agency’s code inventory</h2>
+<h3>Step 1. Reach out to bureaus and offices</h3>
 <p>Federal agencies should include in their inventories custom code built or procured by subsidiary bureaus and offices.  The process of engaging bureaus and offices should help identify (1) what custom code is being developed, (2) who’s developing, (3) where the code repositories are being hosted, and (4) what development environments are being used. Not only will this information be helpful in building the agency’s inventories, but may also highlight areas for efficiency improvements and cost savings.</p>
 <p>Do any of your bureaus have innovative or promising approaches to managing their code? Do they have an opportunity to connect and share best practices regarding custom-code development or procurement? When reaching out to subsidiary bureaus and offices take the opportunity to highlight success stories and build communities of practices across your agencies.</p>
-<h3><a id="Step_2_Find_the_source_code_16"></a>Step 2. Find the source code</h3>
+<h3>Step 2. Find the source code</h3>
 <p>After reaching out to offices that procure or develop custom-code, you may have a better sense of the bounds of your source-code universe. Identify which, if any, source code hosting services your offices use (e.g., Bitbucket, GitHub, Gitlab). For each service or hosting option, you’ll want to list (1) what code sets are located there, (2) the project name,  (3) what licenses exist for the source code, (4) access, and (5) the project owner organization. See below for example:</p>
 <table class="table table-striped table-bordered">
 <thead>
@@ -51,24 +51,29 @@
 </tr>
 </tbody>
 </table>
-<h3><a id="Step_3_Compile_a_draft_26"></a>Step 3. Compile a draft</h3>
+<h3>Step 3. Compile a draft</h3>
 <p>From the table or list you’ve provided in the previous step, you will be able to create a rough draft of your agency’s inventory. The more complete this table is, the easier it will be to compile the inventory. Regardless of whether the project is open source or closed subject to an exemption, each project should not only have an organizational owner but also a license which describes the terms of its use. For more information about licensing, please review our advice on licensing here: (insert link).</p>
 <h3><a id="Step_4_Prepare_for_public_consumption_29"></a>Step 4. Prepare for public consumption</h3>
-<p>When preparing your agency’s code inventory, make sure that you have included all the required fields as define by the latest version of the metadata schema(insert link). The <a href="http://code.gov">code.gov</a> discovery platform will validate each agency’s inventory against the format of the metadata schema and invalid inventories will not be accepted. If your agency plans to close a repository to government reuse (and, by extension, open source discovery) the agency must provide a justification for relying on one of the five exceptions stated in the source code policy. Each exception must be approved and documented by the agency’s CIO in prior to public release of the agency’s code inventory.</p>
-<p><strong>Redactions - Government Reuse</strong></p>
+<p>When preparing your agency’s code inventory, make sure that you have included all the required fields as define by the latest version of the metadata schema(insert link). The <a href="http://code.gov">Code.gov</a> discovery platform will validate each agency’s inventory against the format of the metadata schema and invalid inventories will not be accepted. If your agency plans to close a repository to government reuse (and, by extension, open source discovery) the agency must provide a justification for relying on one of the five exceptions stated in the source code policy. Each exception must be approved and documented by the agency’s CIO in prior to public release of the agency’s code inventory.</p>
+<h4>Redactions - Government Reuse</h4>
 <p>For code repositories limited to government reuse is permitted (not open source), agencies should redact the ‘repository’ field before compiling the inventory. Redaction can be as simple as removing the URL path to the project and replacing with the words ‘[REDACTED - FOR GOVERNMENT REUSE ONLY]’.</p>
-<p><strong>Redactions - Closed</strong>
-Code repositories that are closed (i.e., not available as open source or government reuse) <em>should still be included in an agency’s inventory</em>. For example, agencies should redact the ‘repository’ field, any project tags identifying the project or the source code, before compiling the inventory. Redaction can be as simple as removing the URL path to the project and replacing with the words ‘[REDACTED - PURSUANT TO EXEMPTION #].’ Agencies should redact fields necessary to comply with the exceptions set forth in the source code policy.</p>
-<h3><a id="Step_5_Build_the_schema_40"></a>Step 5. Build the schema</h3>
-<p>Using the resources provided below to automate the creation of your repository where possible. Once complete please name the file ‘code.json’ and use a JSON validator (links included in the <a href="https://github.com/presidential-innovation-fellows/code-gov-tools">code-gov-tools repository</a>)  to validate the inventory is compliant with the latest form of the latest <a href="http://code.gov">code.gov</a> metadata schema. Once confirmed please upload ‘code.json’ into the root folder (e.g. <a href="https://gsa.gov/code.json">https://gsa.gov/code.json</a>) of your agency’s website. The <a href="http://code.gov">code.gov</a> discovery platform will scan the root directory daily for the latest version of the file.</p>
-<h1><a id="Frequently_Asked_Questions_44"></a>Frequently Asked Questions</h1>
-<h2><a id="How_do_I_build_my_agencys_inventory_if_my_code_is_stored_on__Github_Bitbucket_Gitlab_etc__45"></a>How do I build my agency’s inventory if my code is stored on … [Github, Bitbucket, Gitlab, etc.] ?</h2>
-<p>We will be preparing a list of tools and resources to accomodate mapping and conversion to the <a href="http://code.gov">code.gov</a> metadata schema. We will prioritize the development of those tools based on use/ demand by government agencies.</p>
+<h4>Redactions - Closed</h4>
+<p>Code repositories that are closed (i.e., not available as open source or government reuse) <em>should still be included in an agency’s inventory</em>. For example, agencies should redact the ‘repository’ field, any project tags identifying the project or the source code, before compiling the inventory. Redaction can be as simple as removing the URL path to the project and replacing with the words ‘[REDACTED - PURSUANT TO EXEMPTION #].’ Agencies should redact fields necessary to comply with the exceptions set forth in the source code policy.</p>
+<h3>Step 5. Build the schema</h3>
+<p>Using the resources provided below to automate the creation of your repository where possible. Once complete please name the file ‘code.json’ and use a JSON validator (links included in the <a href="https://github.com/presidential-innovation-fellows/code-gov-tools">code-gov-tools repository</a>) to validate the inventory is compliant with the latest form of the latest <a href="http://code.gov">Code.gov</a> metadata schema. Once confirmed please upload ‘code.json’ into the root folder (e.g. <a href="https://gsa.gov/code.json">https://gsa.gov/code.json</a>) of your agency’s website. The <a href="http://code.gov">code.gov</a> discovery platform will scan the root directory daily for the latest version of the file.</p>
+<h2>Frequently Asked Questions</h2>
+<h3>How do I build my agency’s inventory if my code is stored on … [Github, Bitbucket, Gitlab, etc.] ?</h3>
+<p>We will be preparing a list of tools and resources to accomodate mapping and conversion to the <a href="http://code.gov">Code.gov</a> metadata schema. We will prioritize the development of those tools based on use/ demand by government agencies.</p>
 <p><em>For Github</em>:
 Mapping tool: <a href="https://github.com/presidential-innovation-fellows/code-gov-tools">code-gov-tools repository</a>
 Other resources:
-<a href="https://developer.github.com/v3/">https://developer.github.com/v3/</a></p>
+<a external-link href="https://developer.github.com/v3/">https://developer.github.com/v3/</a></p>
 <p><em>For Bitbucket</em>
-Resources: <a href="https://confluence.atlassian.com/bitbucket/use-the-bitbucket-cloud-rest-apis-222724129.html">https://confluence.atlassian.com/bitbucket/use-the-bitbucket-cloud-rest-apis-222724129.html</a></p>
-<h2><a id="What_tools_are_available_to_help_me_build_my_agencys_inventory_58"></a>What tools are available to help me build my agency’s inventory?</h2>
+Resources: <a external-link href="https://confluence.atlassian.com/bitbucket/use-the-bitbucket-cloud-rest-apis-222724129.html">https://confluence.atlassian.com/bitbucket/use-the-bitbucket-cloud-rest-apis-222724129.html</a></p>
+<h3>What tools are available to help me build my agency’s inventory?</h3>
 <p>You can find links to our suite of tools here at the <a href="https://github.com/presidential-innovation-fellows/code-gov-tools">code-gov-tools repository</a></p>
+Mapping tool: (insert link)
+<p>
+Other resources: <a external-link href="https://confluence.atlassian.com/bitbucket/use-the-bitbucket-cloud-rest-apis-222724129.html">https://confluence.atlassian.com/bitbucket/use-the-bitbucket-cloud-rest-apis-222724129.html</a></p>
+<h3>What tools are available to help me build my agency’s inventory?</h3>
+<p>go here: [link to separate guidance on tools agencies can use to build inventory]</p>

--- a/src/app/components/policy-guide/docs/compliance/compliance-measuring-code/compliance-measuring-code.template.html
+++ b/src/app/components/policy-guide/docs/compliance/compliance-measuring-code/compliance-measuring-code.template.html
@@ -6,15 +6,14 @@
 <li>Choose a method of measuring the size of code</li>
 <li>Apply the measurement method to the total enterprise code inventory to establish a baseline</li>
 </ul>
-<p>&nbsp;</p>
 <h2>Choosing a measure</h2>
 <p>Having established an inventory of new custom-developed code, agencies will still need to determine their method of measuring the amount of code it represents. The Open Source community and Federal developers have suggested a number of options that agencies may choose from. These include:</p>
 <ul>
-<li>source lines of code</li>
-<li>number of self-contained modules</li>
-<li>cost</li>
-<li>number of software projects</li>
-<li>system certification and accreditation boundaries</li>
+<li>Source lines of code</li>
+<li>Number of self-contained modules</li>
+<li>Cost</li>
+<li>Number of software projects</li>
+<li>System certification and accreditation boundaries</li>
 </ul>
 <p>This list is not exhaustive and agencies should choose the most appropriate measure for their organization. When choosing a measure, agencies should consider the following factors:</p>
 <ul>
@@ -28,6 +27,6 @@
 <p>Things to consider include:</p>
 <ul>
 <li>This requirement complements the requirement to account for 100% of new custom-developed code in your agency&rsquo;s enterprise code inventory (or in the form of exemptions from inclusion in the inventory). Importantly, for the purposes of calculating your total amount of custom code, agencies <em>should include </em>code that is unlikely or certain not to be released for reasons of national security or the other exemptions related to the Code Inventory.</li>
-<li>Remember that the Source Code Policy requires each agency to release "20% of its new custom-developed code each year for the term of the pilot program" and does not apply retroactively. However, making such code available for Government-wide reuse or as OSS, to the extent practicable, is strongly encouraged.&nbsp;</li>
-<li>In defining "custom code", the Source Code Policy allows agencies to exclude "code that is truly exploratory or disposable in nature, such as that written by a developer experimenting with a new language or library." As with measuring the size of code, agencies should adopt a consistent, justifiable approach to determining whether code qualifies and can be excluded from the enterprise code inventory nd open source pilot. In that context, agencies should err on the side of including code.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</li>
+<li>Remember that the Source Code Policy requires each agency to release "20% of its new custom-developed code each year for the term of the pilot program" and does not apply retroactively. However, making such code available for Government-wide reuse or as OSS, to the extent practicable, is strongly encouraged.</li>
+<li>In defining "custom code", the Source Code Policy allows agencies to exclude "code that is truly exploratory or disposable in nature, such as that written by a developer experimenting with a new language or library." As with measuring the size of code, agencies should adopt a consistent, justifiable approach to determining whether code qualifies and can be excluded from the enterprise code inventory nd open source pilot. In that context, agencies should err on the side of including code.</li>
 </ul>

--- a/src/app/components/policy-guide/docs/compliance/compliance-metadata-schema/compliance-metadata-schema.template.html
+++ b/src/app/components/policy-guide/docs/compliance/compliance-metadata-schema/compliance-metadata-schema.template.html
@@ -1,14 +1,14 @@
 <h1>Specification for Metadata Schema</h1>
-<h2><a id="Overview"></a>Overview</h2>
+<h2>Overview</h2>
 <p>Section 7.2 and 7.3 of the Federal Source Code Policy requires agencies to provide an inventory of their 'custom-developed code' to support government-wide reuse and make Federal open source code easier to find.</p>
-<p>Specification</p>
-<h3><a id="File_location_and_contents"></a>File location and contents</h3>
+<h2>Specification</h2>
+<h3>File location and contents</h3>
 <ul>
 <li><code>code.json</code> must live in the root directory of your agency’s website.</li>
 <li><code>code.json</code> must include a single object represented as JSON, with key-value pairs according to the list below.</li>
 </ul>
-<h3><a id="Fields"></a>Fields</h3>
-<h4><a id="Required"></a>Required</h4>
+<h3>Fields</h3>
+<h4>Required</h4>
 <ul>
 <li><code>agency</code>: [string] The agency acronym. For example "GSA" or "DOD"</li>
 <li><code>organization</code>: [string] The organization within the agency that the projects listed belong to. For example, "18F" or "Navy".</li>
@@ -51,7 +51,7 @@
 </ul>
 </li>
 </ul>
-<h4><a id="Optional"></a>Optional</h4>
+<h4>Optional</h4>
 <ul>
 <li><code>project</code>: [object] Contains objects representing each software project
 <ul>
@@ -96,5 +96,5 @@
 </ul>
 </li>
 </ul>
-<h2><a id="Example_codejson"></a>Example <code>code.json</code></h2>
-<p>We’ve created a <a href="https://github.com/presidential-innovation-fellows/code-gov-web/blob/master/_draft_content/02_compliance/schema/code.json">sample <code>code.json</code></a>.</p>
+<h2>Example code.json File</h2>
+<p>We’ve created a <a href="https://github.com/presidential-innovation-fellows/code-gov-web/blob/master/_draft_content/02_compliance/schema/code.json">sample code.json</a>.</p>

--- a/src/app/components/policy-guide/docs/compliance/compliance-whats-required/compliance-whats-required.template.html
+++ b/src/app/components/policy-guide/docs/compliance/compliance-whats-required/compliance-whats-required.template.html
@@ -1,36 +1,75 @@
-<h1><a id="THIS_DOCUMENT_IS_NOW_BEING_DEVELOPED_ON_CODEGOVWEB_0"></a>THIS DOCUMENT IS NOW BEING DEVELOPED ON CODE-GOV-WEB</h1>
-<h1><a id="Overview__Whats_Required_2"></a>Overview - What’s Required?</h1>
-<p>The Federal Source Code Policy was issued on August 8, 2016 and requires both agencies and OMB to take specific actions within 90 and 120 days, as well as on an ongoing basis. This section of <a href="http://Code.gov">Code.gov</a> is designed to help agencies understand what is required by the policy and when those requirements kick in. Agencies should treat the content here as purely advisory and rely primarily on the text of the policy to satisfy their obligations. If there is any inconsistency between the Federal Source Code Policy and the implementation advice that appears on <a href="http://Code.gov">Code.gov</a>, the text of the policy will prevail.</p>
-<h2><a id="Milestone__90_Days_6"></a>Milestone - 90 Days</h2>
-<p>November 6 will mark 90 days from the issuance of the policy. By November 6, the following must be accomplished:</p>
+<h1>Overview - What’s Required?</h1>
+<p>
+  The Federal Source Code Policy was issued on August 8, 2016 and requires both agencies and OMB to take specific actions within 90 and 120 days, as well as on an ongoing basis. This section of <a href="http://Code.gov">Code.gov</a> is designed to help agencies understand what is required by the policy and when those requirements kick in. Agencies should treat the content here as purely advisory and rely primarily on the text of the policy to satisfy their obligations. If there is any inconsistency between the Federal Source Code Policy and the implementation advice that appears on <a href="http://Code.gov">Code.gov</a>, the text of the policy will prevail.
+</p>
+<h2>Milestone - 90 Days</h2>
+<p>
+  November 6 will mark 90 days from the issuance of the policy. By November 6, the following must be accomplished:
+</p>
 <ul>
-<li>OMB must:</li>
-<li>Launch <a href="http://Code.gov">Code.gov</a></li>
-<li>Provide content on <a href="http://Code.gov">Code.gov</a> regarding:</li>
-<li>How best to measure source code (5.1)</li>
-<li>Advice on how agencies can strengthen internal capacity to efficiently and securely deliver OSS as part of regular operations (7.1)</li>
-<li>Advice on existing code repositories and common third-party repository platforms that agencies can use to satisfy the requirements of this policy (7.4)</li>
-<li>Advice on various open source licenses that agencies can use when releasing custom-developed code as OSS (7.5)</li>
-<li>Insight into how agency implementation of this policy will be assessed by OMB (7.7)</li>
-<li>Agencies must:
-<ul>
-<li>Develop an agency-wide policy that addresses the requirements of the Source Code Policy and correct or amend any policies that are inconsistent with the requirements of the Source Code Policy (7.6)</li>
+  <li>
+    OMB must:
+    <ul>
+      <li>Launch <a href="http://Code.gov">Code.gov</a></li>
+      <li>Provide content on <a href="http://Code.gov">Code.gov</a> regarding:
+        <ul>
+          <li>
+            How best to measure source code (5.1)
+          </li>
+          <li>
+            Advice on how agencies can strengthen internal capacity to efficiently and securely deliver OSS as part of regular operations (7.1)
+          </li>
+          <li>
+            Advice on existing code repositories and common third-party repository platforms that agencies can use to satisfy the requirements of this policy (7.4)
+          </li>
+          <li>
+            Advice on various open source licenses that agencies can use when releasing custom-developed code as OSS (7.5)
+          </li>
+          <li>
+            Insight into how agency implementation of this policy will be assessed by OMB (7.7)
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+  <li>Agencies must:
+    <ul>
+      <li>
+        Develop an agency-wide policy that addresses the requirements of the Source Code Policy and correct or amend any policies that are inconsistent with the requirements of the Source Code Policy (7.6)
+      </li>
+    </ul>
+  </li>
 </ul>
-</li>
-</ul>
-<h2><a id="Milestone__120_Days_19"></a>Milestone - 120 Days</h2>
+<h2>Milestone - 120 Days</h2>
 <p>December 6 will mark 120 days from the issuance of the policy. By December 6, the following must be accomplished:</p>
-<ul>
-<li>OMB must:</li>
-<li>Provide content on <a href="http://Code.gov">Code.gov</a> regarding:</li>
-<li>Metrics to assess the impact of the pilot program (5.1)</li>
-<li>Metadata schema to help agencies fill out their enterprise code inventories (7.2)</li>
-<li>Agencies must:</li>
-<li>Update their enterprise code inventories using the metadata schema provided by OMB (7.2)</li>
+  <ul>
+  <li>
+    OMB must:
+    <ul>
+      <li>Provide content on <a href="http://Code.gov">Code.gov</a> regarding:
+        <ul>
+          <li>
+            Metrics to assess the impact of the pilot program (5.1)
+          </li>
+          <li>
+            Metadata schema to help agencies fill out their enterprise code inventories (7.2)
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+  <li>
+    Agencies must:
+    <ul>
+      <li>
+        Update their enterprise code inventories using the metadata schema provided by OMB (7.2)
+      </li>
+    </ul>
+  </li>
 </ul>
-<h1><a id="Day_121_and_onward_28"></a>Day 121 and onward</h1>
+<h1>Day 121 and onward</h1>
 <p>After these initial deliverables have been met, OMB and agencies will work together to drive implementation and capacity building across the Executive Branch. Generally, agencies should plan to:</p>
 <ul>
-<li>Update, refine, and expand their code inventories to promote government-wide sharing and reuse of code; and</li>
-<li>Build their internal open source pipeline in order to efficiently develop and publish open source code as part of the pilot program.</li>
+  <li>Update, refine, and expand their code inventories to promote government-wide sharing and reuse of code; and</li>
+  <li>Build their internal open source pipeline in order to efficiently develop and publish open source code as part of the pilot program.</li>
 </ul>

--- a/src/app/components/policy-guide/docs/docs.component.ts
+++ b/src/app/components/policy-guide/docs/docs.component.ts
@@ -1,9 +1,10 @@
-import { Component } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 
 @Component({
   selector: 'docs',
   styles: [require('./docs.style.scss')],
-  template: require('./docs.template.html')
+  template: require('./docs.template.html'),
+  encapsulation: ViewEncapsulation.None
 })
 export class DocsComponent {
 

--- a/src/app/components/policy-guide/docs/docs.style.scss
+++ b/src/app/components/policy-guide/docs/docs.style.scss
@@ -8,13 +8,69 @@
   @include media($extra-large-screen) {
     padding: 2.5em 2em;
   }
+
+  a {
+    color: darken($brand-teal, 10);
+    text-decoration: none;
+
+    &:hover {
+      color: darken($brand-teal, 20);
+    }
+  }
+
+  blockquote {
+    background-color: lighten($color-gray-lightest, 2);
+    border-left: 6px solid $brand-purple;
+    color: darken($color-gray, 6);
+    margin: 1.5em 0;
+    padding: 1em 1em 1em 2.5em;
+
+    p {
+      font-size: 0.95em;
+
+      &:first-child {
+        margin-top: 0;
+      }
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+  }
+
+  code {
+    background-color: $brand-blue-gray;
+    border-radius: 3px;
+    color: $brand-teal;
+    font-size: 0.9em;
+    padding: 2px 3px;
+  }
+
+  li {
+    color: $color-gray;
+
+    p {
+      font-size: 1em;
+    }
+
+    ul {
+      margin-top: 0.2em;
+      padding-left: 1.25em;
+    }
+  }
 }
 
 .policy-guide-subnav {
   @include span-columns(3);
 
+  .usa-sidenav-list {
+
+    a {
+      color: $color-gray-lightest;
+    }
+  }
+
   a {
-    color: $color-gray-lightest;
     font-size: 0.95em;
     text-decoration: none;
 

--- a/src/app/components/policy-guide/docs/docs.template.html
+++ b/src/app/components/policy-guide/docs/docs.template.html
@@ -9,16 +9,6 @@
           </a>
         </li>
         <li>
-          <a routerLink="overview/inventory" routerLinkActive="usa-current">
-            Inventory and Sharing
-          </a>
-        </li>
-        <li>
-          <a routerLink="overview/pilot" routerLinkActive="usa-current">
-            Open Source Pilot
-          </a>
-        </li>
-        <li>
           <a routerLink="overview/tracking-progress" routerLinkActive="usa-current">
             Tracking Progress
           </a>
@@ -34,18 +24,8 @@
           </a>
         </li>
         <li>
-          <a routerLink="compliance/acquiring-code" routerLinkActive="usa-current">
-            Acquiring Code
-          </a>
-        </li>
-        <li>
           <a routerLink="compliance/measuring-code" routerLinkActive="usa-current">
             Measuring Code
-          </a>
-        </li>
-        <li>
-          <a routerLink="compliance/licensing" routerLinkActive="usa-current">
-            Licensing
           </a>
         </li>
         <li>
@@ -69,23 +49,8 @@
           </a>
         </li>
         <li>
-          <a routerLink="capacity-building/basics" routerLinkActive="usa-current">
-            The Basics
-          </a>
-        </li>
-        <li>
           <a routerLink="capacity-building/security" routerLinkActive="usa-current">
             Security and Open Source
-          </a>
-        </li>
-        <li>
-          <a routerLink="capacity-building/collaboration" routerLinkActive="usa-current">
-            Collaboration
-          </a>
-        </li>
-        <li>
-          <a routerLink="capacity-building/interagency-sharing" routerLinkActive="usa-current">
-            Interagency Code Sharing
           </a>
         </li>
         <li>

--- a/src/app/components/policy-guide/docs/overview/overview-tracking-progress/overview-tracking-progress.template.html
+++ b/src/app/components/policy-guide/docs/overview/overview-tracking-progress/overview-tracking-progress.template.html
@@ -1,10 +1,25 @@
-<h1>OMB&rsquo;s Assessment of Agency Progress</h1>
-<p><a href="https://policy.cio.gov/source-code/implementation/#accountability-mechanisms">Section 7.7</a>&nbsp;of the Federal Source Code Policy states that:</p>
-<p><em>Progress on agency implementation of this policy will be primarily assessed by OMB through an analysis of each agency&rsquo;s internal Government repositories, public OSS repositories, and code inventories on Code.gov, as well as data obtained through the quarterly Integrated Data Collection (IDC), quarterly PortfolioStat sessions, the IT Dashboard, and additional mechanisms [..]</em></p>
-<p>Generally, OMB's approach to measuring and assessing agency progress in meeting the Source Code Policy's requirements can be broken into two categories: (1) analysis of agencies' enterprise code inventories, individual code repositories, and open sourced code, with a (2) comparison of that information against overall operational and financial data collected by OMB.</p>
+<h1>OMB’s Assessment of Agency Progress</h1>
+<p>
+  <a href="https://policy.cio.gov/source-code/implementation/#accountability-mechanisms">
+    Section 7.7
+  </a>
+  of the Federal Source Code Policy states that:
+</p>
+<blockquote class="usa-quote">
+  <p>
+    Progress on agency implementation of this policy will be primarily assessed by OMB through an analysis of each agency’s internal Government repositories, public OSS repositories, and code inventories on Code.gov, as well as data obtained through the quarterly Integrated Data Collection (IDC), quarterly PortfolioStat sessions, the IT Dashboard, and additional mechanisms [..]
+  </p>
+</blockquote>
+<p>
+  Generally, OMB's approach to measuring and assessing agency progress in meeting the Source Code Policy's requirements can be broken into two categories: (1) analysis of agencies' enterprise code inventories, individual code repositories, and open sourced code, with a (2) comparison of that information against overall operational and financial data collected by OMB.
+</p>
 <p>OMB will provide additional information about its assessment mechanisms over time.</p>
-<h2>Analysis of Each Agency&rsquo;s Custom Code</h2>
-<p>OMB will regularly review each agency&rsquo;s enterprise code inventory to ensure that the agency is satisfying the requirements of the Source Code Policy. This review will include both the agency&rsquo;s internal Government repositories and public open source repositories to ensure that each agency&rsquo;s enterprise code inventory is properly reflected on &ndash; and easily discoverable through &ndash; this website.</p>
+<h2>Analysis of Each Agency’s Custom Code</h2>
+<p>
+  OMB will regularly review each agency&rsquo;s enterprise code inventory to ensure that the agency is satisfying the requirements of the Source Code Policy. This review will include both the agency&rsquo;s internal Government repositories and public open source repositories to ensure that each agency&rsquo;s enterprise code inventory is properly reflected on &ndash; and easily discoverable through &ndash; this website.
+</p>
 <h2>Analysis of Overall Data</h2>
-<p>OMB collects agency data through a number of existing mechanisms, including quarterly PortfolioStat sessions and the Integrated Data Collection. Much of this data is publicly available on ITDashboard.gov. OMB will use this data and other relevant information to better understand the overall impact of the Source Code Policy over time.</p>
+<p>
+  OMB collects agency data through a number of existing mechanisms, including quarterly PortfolioStat sessions and the Integrated Data Collection. Much of this data is publicly available on ITDashboard.gov. OMB will use this data and other relevant information to better understand the overall impact of the Source Code Policy over time.
+</p>
 

--- a/src/app/components/policy-guide/policy-guide.template.html
+++ b/src/app/components/policy-guide/policy-guide.template.html
@@ -22,3 +22,5 @@
     <router-outlet></router-outlet>
   </div>
 </div>
+
+<modal></modal>


### PR DESCRIPTION
Improves content formatting by modifying HTML element usage, adds styles for the Policy Guide, and adds External Link dialog to external links in the Policy Guide.

* Use blockquote for quoting the policy
* Remove most empty a tags with ids only
* Remove most h1 tags in favor of h2/h3s where appropriate
* Add external-link directive to external links
* Add modal component to Policy Guide
* Add styles to doc and remove View Encapsulation to ensure styles traverse sub components