### PR TITLE
swapped policy.cio.gov-->sourcecode.cio.gov

### DIFF
--- a/src/app/components/policy-guide/docs/capacity/capacity-introduction/capacity-introduction.template.html
+++ b/src/app/components/policy-guide/docs/capacity/capacity-introduction/capacity-introduction.template.html
@@ -1,9 +1,9 @@
 <h1>Introduction - Building Your Agency's Open Source Practice</h1>
 <p>
-Section 5 of the Source Code Policy outlines an Open Source Pilot Program that requires the release of a portion of Federal source code over the next three years. This section of code.gov provides advice for agencies in satisfying the requirements of the pilot.
+<a href="https://sourcecode.cio.gov/OSS#open-source-software">Section 5 of the Federal Source Code Policy</a> outlines an Open Source Pilot Program that requires the release of a portion of Federal source code over the next three years. This section of code.gov provides advice for agencies in satisfying the requirements of the pilot.
 </p>
 <p>The open source practice for the U.S. government is expected to rapidly evolve and become more sophisticated over the next several years, so the advice provided here will also evolve.</p>
-<p>In addition to the requirements outline in section 5 of the policy, <a href="https://policy.cio.gov/source-code/implementation/">Section 7.1</a> of the policy discusses roles and responsibilities within agencies in meeting the requirements of the policy. Regarding the Open Source Pilot Program specifically, it notes that:</p>
+<p>In addition to the requirements outline in <a href="https://sourcecode.cio.gov/OSS#open-source-software">Section 5</a> of the policy, <a href="https://sourcecode.cio.gov/Implementation/#roles-and-responsibilities">Section 7.1</a> of the policy discusses roles and responsibilities within agencies in meeting the requirements of the policy. Regarding the Open Source Pilot Program specifically, it notes that:</p>
 <blockquote>
   <p>
     Agencies should strengthen internal capacity to efficiently and securely deliver OSS as part of regular operations.
@@ -15,7 +15,7 @@ Section 5 of the Source Code Policy outlines an Open Source Pilot Program that r
 <p>Agencies and teams that have been most successful in establishing their open source practice have benefited from engaged and supportive agency leadership who have helped teams navigate key legal, security, and operational issues. Strong engagement from the agency CIO and other leadership can have the effect of convening the necessary stakeholders to have a serious conversation. It can also greatly accelerate the establishment of clear, repeatable processes and foundational policy. With this foundation in place, your agency's teams can refine policy and process as they learn together.</p>
 
 <h2>Open Source is an interdisciplinary practice</h2>
-<p>Section 7.1 of the policy provides a long (and non-exhaustive) list of individuals and teams who have a role in your agency's open source practice:</p>
+<p> <a href="https://sourcecode.cio.gov/Implementation/#roles-and-responsibilities">Section 7.1</a> of the policy provides a long (and non-exhaustive) list of individuals and teams who have a role in your agency's open source practice:</p>
 <blockquote>
   <p>
     [..] agency heads must ensure that CIOs and Senior Agency Officials,including CAOs, are positioned with the responsibility and authority necessary to implement the requirements of this policy. As appropriate, Senior Agency Officials should also work with the agency&rsquo;s public affairs staff, open government staff, web manager or digital strategist, program owners, and other leadership to properly identify, publish, and collaborate with communities on their OSS projects.

--- a/src/app/components/policy-guide/docs/capacity/capacity-resources/capacity-resources.template.html
+++ b/src/app/components/policy-guide/docs/capacity/capacity-resources/capacity-resources.template.html
@@ -1,5 +1,5 @@
 <h1>Tools and Resources</h1>
-<p><a href="https://policy.cio.gov/source-code/implementation/#code-repositories">Section 7.4</a>&nbsp;of the Source Code Policy states:</p>
+<p><a href="https://sourcecode.cio.gov/Implementation/#code-repositories">Section 7.4</a>&nbsp;of the Federal Source Code Policy states:</p>
 <blockquote>
   <p>
     Accessible, buildable, version-controlled repositories for the storage, discussion, and modification of custom-developed code are critical to both the Government-wide reuse and OSS pilot program sections of this policy. Agencies should utilize existing code repositories and common third-party repository platforms as necessary in order to satisfy the requirements of this policy.
@@ -25,13 +25,13 @@
 <h2>Code quality and security</h2>
 <p>A number of paid and free tools exist that agencies can use as part of their development process that, if used appropriately, should lower the risk that inappropriate or insecure content is released.&nbsp; Because these tools can help automate some processes that would otherwise be manual, they can simultaneously help lower costs overall.</p>
 <p>Increasingly, these tools can be configured to reflect the specific security policies of your agency and can be integrated directly into your agency's developer workflow, scanning code automatically whenever code is committed or pushed for passwords, keys, watchwords, and other potentially sensitive information. Some tools also provide broader capabilities related to coding standards and quality. In developing its overall source code strategy, your agency may want to consider integrating these kinds of tools into your developer workflow, contractually require their use by vendors, or use them to assess the quality and security of deliverables prior to accepting receipt.</p>
-<p>We are soliciting input from the development community in building out a list of tools. Agencies should feel free to join the conversation, make suggestions, and ask questions on the <a href="https://github.com/presidential-innovation-fellows/code-gov-web/issues/101">open issue on the code.gov repository</a>.</p>
+<p>We are soliciting input from the development community in building out a list of tools. Agencies should feel free to join the conversation, make suggestions, and ask questions on the <a href="https://github.com/presidential-innovation-fellows/code-gov-web/issues/101">open Issue on the code.gov repository</a>.</p>
 <h2>Development practices for government</h2>
 <p>A number of communities of practice exist that agency staff can use to keep abreast of open source inside and outside of government, to raise questions, and to share their experiences.&nbsp;</p>
 <ul>
 <li>Open Source Listserv (GSA, open to government only)</li>
 <li>Security Listserv (GSA, open to government only)</li>
 <li>Digital Service Listserv (GSA, open to government only)</li>
-<li><a external-link href="https://github.com/government/welcome#readme">Github for Government Community</a> (Not an official Government service.)</li>
+<li><a external-link href="https://github.com/government/welcome#readme">Github for Government Community</a> (Not an official Government service)</li>
 </ul>
 <p>As a quick reminder, agency staff must comply with applicable law and regulations and should obtain the appropriate agency approvals prior to using any of the tools ans services discussed here.</p>

--- a/src/app/components/policy-guide/docs/compliance/compliance-inventory-code/compliance-inventory-code.template.html
+++ b/src/app/components/policy-guide/docs/compliance/compliance-inventory-code/compliance-inventory-code.template.html
@@ -1,7 +1,7 @@
 <h1>Creating your enterprise code inventory</h1>
 <h2>Overview</h2>
-<p>Section 7.2 and 7.3 of the Source Code Policy require agencies to provide an inventory of their 'custom-developed code' to support government-wide reuse and make Federal open source code easier to find.</p>
-<p>Using these inventories, code.gov will provide a platform to find custom-developed source code including that released as open source software and that which isn't open source but is available for government-wide reuse. It will compile an aggregate source code inventory for the Federal government.</p>
+<p>Section <a href="https://sourcecode.cio.gov/Implementation/#code-inventories-and-discovery">7.2</a> and <a href="https://sourcecode.cio.gov/Implementation/#codegov">7.3</a> of the Source Code Policy require agencies to provide an inventory of their 'custom-developed code' to support government-wide reuse and make Federal open source code easier to find.</p>
+<p>Using these inventories, <a href="https://Code.gov">Code.gov</a> will provide a platform to find custom-developed source code including that released as open source software and that which isn't open source but is available for government-wide reuse. It will compile an aggregate source code inventory for the Federal government.</p>
 
 <h2>Publishing Your Agency's Inventory</h2>
 <p>Agencies are required publish their inventories using a standard metadata schema - a JSON file that they'll make available on their agency websites. Version 1.0 of the metadata schema is now available and agencies are actively inventorying their code in preparation for publication.</p>
@@ -9,12 +9,12 @@
 <p>Agencies should make the “code.json” available in the root folder of their website (e.g., https://www.{{agency}}.gov/code.json). Code.gov will then retrieve these JSON files daily and compile them.</p>
 
 <h2>Specification for the Metadata Schema</h2>
-<h3>File location and contents</h3>
+<h3>File location and contents:</h3>
 <ul>
 <li><code>code.json</code> must live in the root directory of your agency’s website.</li>
 <li><code>code.json</code> must include a single object represented as JSON, with key-value pairs according to the list below.</li>
 </ul>
-<h3>Fields</h3>
+<h3>Fields:</h3>
 <h4>Required</h4>
 <ul>
 <li><code>agency</code>: [string] The agency acronym. For example "GSA" or "DOD"</li>
@@ -103,5 +103,5 @@
 </ul>
 </li>
 </ul>
-<h2>Example code.json File</h2>
+<h2>Example code.json file</h2>
 <p>We’ve created a <a href="https://github.com/presidential-innovation-fellows/code-gov-web/blob/master/_draft_content/02_compliance/schema/code.json">sample code.json</a>.</p>

--- a/src/app/components/policy-guide/docs/compliance/compliance-measuring-code/compliance-measuring-code.template.html
+++ b/src/app/components/policy-guide/docs/compliance/compliance-measuring-code/compliance-measuring-code.template.html
@@ -1,5 +1,5 @@
 <h1>Measuring Source Code</h1>
-<p>As part of the Open Source Pilot Program the Source Code Policy requires that:</p>
+<p>As part of the Open Source Pilot Program the Federal Source Code Policy requires that:</p>
 <blockquote class="usa-quote">
 	<p>Each agency shall release as OSS at least 20 percent of its new custom-developed code each year.</p>
 </blockquote>
@@ -19,9 +19,9 @@
 </ul>
 <p>This list is not exhaustive and agencies should choose the most appropriate measure for their organization. When choosing a measure, agencies should consider the following factors:</p>
 <ul>
-<li>Automation. Is it possible to collect the data for the measure automatically or automate aspects of the collection process? For example, can a script be developed to tabulate the number of source lines of code in your repositories?</li>
+<li>Automation. Is it possible to collect the data for the measure automatically or automate aspects of the collection process? For example, can a script be developed to tabulate the number of lines of source code in your repositories?</li>
 <li>Existing processes. Does your agency already collect data or collect systems information that can be repurposed to meet this requirement?</li>
-<li>Approximation. Given the difficulty in definitively calculating most reasonable measures related to this requirement, the policy leaves room for agencies to use approximate or "estimated" measures. For example, the number of source lines of code in a particular codebase may fluctuate day to day. Or if cost is your measure, the development of a particular codebase may have been purchased in combination with other services. Agencies may use approximation in measuring their code but should do so according to a documented, justifiable process that is applied consistently and considers the overall goals of the policy.</li>
+<li>Approximation. Given the difficulty in definitively calculating most reasonable measures related to this requirement, the Federal Source Code Policy leaves room for agencies to use approximate or "estimated" measures. For example, the number of source lines of code in a particular codebase may fluctuate day to day. Or if cost is your measure, the development of a particular codebase may have been purchased in combination with other services. Agencies may use approximation in measuring their code but should do so according to a documented, justifiable process that is applied consistently and considers the overall goals of the policy.</li>
 <li>To the extent practicable, agencies should use a consistent measure across their organization.</li>
 </ul>
 <h2>Measuring your code for the first time</h2>
@@ -29,6 +29,6 @@
 <p>Things to consider include:</p>
 <ul>
 <li>This requirement complements the requirement to account for 100% of new custom-developed code in your agency&rsquo;s enterprise code inventory (or in the form of exemptions from inclusion in the inventory). Importantly, for the purposes of calculating your total amount of custom code, agencies <em>should include </em>code that is unlikely or certain not to be released for reasons of national security or the other exemptions related to the enterprise code inventory.</li>
-<li>Remember that the Source Code Policy requires each agency to release "20% of its new custom-developed code each year for the term of the pilot program" and does not apply retroactively. However, making such code available for Government-wide reuse or as OSS, to the extent practicable, is strongly encouraged.</li>
-<li>In defining "custom code", the Source Code Policy allows agencies to exclude "code that is truly exploratory or disposable in nature, such as that written by a developer experimenting with a new language or library." As with measuring the size of code, agencies should adopt a consistent, justifiable approach to determining whether code qualifies and can be excluded from the enterprise code inventory nd open source pilot. In that context, agencies should err on the side of including code.</li>
+<li>Remember that the Federal Source Code Policy requires each agency to release "20% of its new custom-developed code each year for the term of the pilot program" and does not apply retroactively. However, making such code available for Government-wide reuse or as OSS, to the extent practicable, is strongly encouraged.</li>
+<li>In defining "custom code", the Federal Source Code Policy allows agencies to exclude "code that is truly exploratory or disposable in nature, such as that written by a developer experimenting with a new language or library." As with measuring the size of code, agencies should adopt a consistent, justifiable approach to determining whether code qualifies and can be excluded from the enterprise code inventory nd open source pilot. In that context, agencies should err on the side of including code.</li>
 </ul>

--- a/src/app/components/policy-guide/docs/overview/overview-tracking-progress/overview-tracking-progress.template.html
+++ b/src/app/components/policy-guide/docs/overview/overview-tracking-progress/overview-tracking-progress.template.html
@@ -1,6 +1,6 @@
 <h1>How OMB Will Assess Agency Progress</h1>
 <p>
-  <a href="https://policy.cio.gov/source-code/implementation/#accountability-mechanisms">
+  <a href="https://sourcecode.cio.gov/Implementation/#accountability-mechanisms">
     Section 7.7
   </a>
   of the Federal Source Code Policy states that:
@@ -11,7 +11,7 @@
   </p>
 </blockquote>
 <p>
-  Generally, OMB's approach to assessing agency progress in meeting the Source Code Policy's requirements can be broken into two categories:
+  Generally, OMB's approach to assessing agency progress in meeting the Federal Source Code Policy's requirements can be broken into two categories:
 </p>
 <ol>
   <li>


### PR DESCRIPTION
* added sourcecode.cio.gov
* updated references to 'Federal Source Code Policy'