### PR TITLE
Add Google Tag Manager and Fix Repo Modal Issue

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -17,7 +17,6 @@ const CommonsChunkPlugin = require('webpack/lib/optimize/CommonsChunkPlugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const ForkCheckerPlugin = require('awesome-typescript-loader').ForkCheckerPlugin;
 const HtmlElementsPlugin = require('./html-elements-plugin');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
 const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin');
 const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin');
 
@@ -179,14 +178,6 @@ module.exports = function (options) {
          from: 'src/meta',
       }
      ]),
-
-     new HtmlWebpackPlugin({
-       template: 'src/index.html',
-       title: METADATA.title,
-       chunksSortMode: 'dependency',
-       metadata: METADATA,
-       inject: 'head'
-     }),
 
      new ScriptExtHtmlWebpackPlugin({
        defaultAttribute: 'defer'

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -10,6 +10,7 @@ const commonConfig = require('./webpack.common.js'); // the settings that are co
  * Webpack Plugins
  */
 const DefinePlugin = require('webpack/lib/DefinePlugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 const NamedModulesPlugin = require('webpack/lib/NamedModulesPlugin');
 const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin');
 
@@ -24,7 +25,8 @@ const METADATA = webpackMerge(commonConfig({env: ENV}).metadata, {
   host: HOST,
   port: PORT,
   ENV: ENV,
-  HMR: HMR
+  HMR: HMR,
+  gtmId: 'GTM-MSJCVSA'
 });
 
 /**
@@ -104,6 +106,14 @@ module.exports = function (options) {
           'NODE_ENV': JSON.stringify(METADATA.ENV),
           'HMR': METADATA.HMR,
         }
+      }),
+
+      new HtmlWebpackPlugin({
+        template: 'src/index.html',
+        title: METADATA.title,
+        chunksSortMode: 'dependency',
+        metadata: METADATA,
+        inject: 'head'
       }),
 
       /**

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -11,6 +11,7 @@ const commonConfig = require('./webpack.common.js'); // the settings that are co
  */
 const DedupePlugin = require('webpack/lib/optimize/DedupePlugin');
 const DefinePlugin = require('webpack/lib/DefinePlugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 const IgnorePlugin = require('webpack/lib/IgnorePlugin');
 const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin');
 const NormalModuleReplacementPlugin = require('webpack/lib/NormalModuleReplacementPlugin');
@@ -24,11 +25,14 @@ const WebpackMd5Hash = require('webpack-md5-hash');
 const ENV = process.env.NODE_ENV = process.env.ENV = 'production';
 const HOST = process.env.HOST || 'localhost';
 const PORT = process.env.PORT || 8080;
+
+/** Be sure to update gtmAuth for Final Deployment to WH **/
 const METADATA = webpackMerge(commonConfig({env: ENV}).metadata, {
   host: HOST,
   port: PORT,
   ENV: ENV,
-  HMR: false
+  HMR: false,
+  gtmAuth: 'GTM-M9L9Q5'
 });
 
 module.exports = function (env) {
@@ -195,6 +199,14 @@ module.exports = function (env) {
       //   regExp: /\.css$|\.html$|\.js$|\.map$/,
       //   threshold: 2 * 1024
       // })
+
+      new HtmlWebpackPlugin({
+        template: 'src/index.html',
+        title: METADATA.title,
+        chunksSortMode: 'dependency',
+        metadata: METADATA,
+        inject: 'head'
+      }),
 
       /**
        * Plugin LoaderOptionsPlugin (experimental)

--- a/src/app/components/explore-code/repo/repo.template.html
+++ b/src/app/components/explore-code/repo/repo.template.html
@@ -90,3 +90,4 @@
     </div>
   </div>
 </section>
+<modal></modal>

--- a/src/index.html
+++ b/src/index.html
@@ -21,10 +21,24 @@
   <!-- base url -->
   <base href="<%= htmlWebpackPlugin.options.metadata.baseUrl %>">
 
-
+  <% if (htmlWebpackPlugin.options.metadata.gtmAuth != null) { %>
+    <script>
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','<%=htmlWebpackPlugin.options.metadata.gtmId%>');
+    </script>
+  <% } %>
 </head>
 
 <body>
+  <% if (htmlWebpackPlugin.options.metadata.gtmAuth != null) { %>
+    <noscript>
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M9L9Q5&gtm_auth=<%=htmlWebpackPlugin.options.metadata.gtmAuth%>" height="0" width="0" style="display:none;visibility:hidden">
+      </iframe>
+    </noscript>
+  <% } %>
 
   <app>
     <div class="loading" style="background-color: #485568; bottom: 0; left: 0; position: fixed; right: 0; top: 0">


### PR DESCRIPTION
Adds GTM support for various environments and fixes an issue with the modal component not being rendered in the RepoComponent.

* Add GTM to head
* Use METADATA constant to dynamically define GTM Auth code based on ENV
* Add modal component to RepoComponent template to ensure it renders