### PR TITLE
Fix multiple typos in README, draft content and source

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ conditionals. Styles are encapsulated by default unless the Component has
 
 ## Style Guide
 This app follows the
-[official Angular Stlye Guide](https://angular.io/styleguide). Please ensure you
+[official Angular Style Guide](https://angular.io/styleguide). Please ensure you
 follow the naming conventions defined in this guide.
 
 ## License

--- a/_draft_content/02_compliance/06_how-to-populate-the-your-code-inventory.md
+++ b/_draft_content/02_compliance/06_how-to-populate-the-your-code-inventory.md
@@ -50,7 +50,7 @@ Using the resources provided below to automate the creation of your repository w
 #Frequently Asked Questions#
 ##How do I build my agency's inventory if my code is stored on ... [Github, Bitbucket, Gitlab, etc.] ?##
 
-We will be preparing a list of tools and resources to accomodate mapping and conversion to the code.gov metadata schema. We will prioritize the development of those tools based on use/ demand by government agencies. 
+We will be preparing a list of tools and resources to accommodate mapping and conversion to the code.gov metadata schema. We will prioritize the development of those tools based on use/ demand by government agencies. 
 
 *For Github*: 
 Mapping tool: (insert link)

--- a/_draft_content/02_compliance/07_measuring-source-code.md
+++ b/_draft_content/02_compliance/07_measuring-source-code.md
@@ -33,7 +33,7 @@ Having chosen a measure, your agency will likely need to measure the size of its
 For agencies that, in accordance with [section 7.4 of the Source Code Policy](https://sourcecode.cio.gov/Implementation/#code-repositories) consistently maintain their code in version-controlled repositories, one measure that may be tempting to use is the disk size or version-control system reported size of the repository itself.  While this approach can be workable, agencies should consider several limitations to its accuracy, which may or may not affect their particular systems:
 - repeated commits of code can increase repository size. Repositories that have been under development for longer may be artificially inflated simply because they have a longer "revision history"
 - differing measures between platforms.  There is not a standard method of measuring repository size and so agencies that maintain code on different platforms or different versions of platforms should not assume that repository size is an apples-to-apples comparison between them
-- vendor support. Because of the limited utility of repository size as a measure, vendors may not be commited to providing consistent support to automated reporting of this measure or may change their approach to measuring it over time.
+- vendor support. Because of the limited utility of repository size as a measure, vendors may not be committed to providing consistent support to automated reporting of this measure or may change their approach to measuring it over time.
 
 
 ### Source Lines of Code

--- a/_draft_content/03_building-capacity/12_developing-in-the-open.md
+++ b/_draft_content/03_building-capacity/12_developing-in-the-open.md
@@ -122,7 +122,7 @@ At the most basic level, developing in the open means that developers maintain t
     - design
     - versioning
 - what can't be made public?
- - passowrds
+ - passwords
  - sensitive data
  - 
 

--- a/src/app/components/policy-guide/docs/capacity/capacity-security/capacity-security.template.html
+++ b/src/app/components/policy-guide/docs/capacity/capacity-security/capacity-security.template.html
@@ -126,7 +126,7 @@
 <li>design</li>
 <li>versioning</li>
 <li>what can’t be made public?</li>
-<li>passowrds</li>
+<li>passwords</li>
 <li>sensitive data</li>
 <li></li>
 </ul>


### PR DESCRIPTION
This pull-request fixes multiple typos in the project description file _(aka. README.md)_, some files in the draft content directory and some components in the application source directory.

```
README.md:86:18:
"Stlye" is a misspelling of "Style"

_draft_content/02_compliance/07_measuring-source-code.md:36:101:
"commited" is a misspelling of "committed"

_draft_content/02_compliance/06_how-to-populate-the-your-code-inventory.md:53:54:
"accomodate" is a misspelling of "accommodate"

_draft_content/03_building-capacity/12_developing-in-the-open.md:125:3:
"passowrds" is a misspelling of "passwords"

src/app/components/policy-guide/.../capacity-security.template.html:129:4:
"passowrds" is a misspelling of "passwords"
```