### PR TITLE
Use Absolute Paths for Social Images

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -13,11 +13,11 @@
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="600">
 
-  <meta property="twitter:image:src" content="assets/img/og.jpg">
+  <meta property="twitter:image:src" content="https://code.gov/assets/img/og.jpg">
   <meta property="twitter:image:width" content="1200">
   <meta property="twitter:image:height" content="600">
 
-  <link rel="image_src" type="image/jpeg" href="assets/img/og.jpg">
+  <link rel="image_src" type="image/jpeg" href="https://code.gov/assets/img/og.jpg">
 
   <link rel="stylesheet" href="assets/fonts.css">
   <link rel="stylesheet" href="assets/uswds.min.css">


### PR DESCRIPTION
Changes image paths from relative to absolute.

* Use absolute image paths for Twitter and Facebook image URLs