### PR TITLE
fix: removed 2 old and one renamed tslint rule (issue #146)

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -98,7 +98,6 @@
     "interface-name": false,
     "jsdoc-format": true,
     "no-consecutive-blank-lines": false,
-    "no-parameter-properties": false,
     "one-line": [
       true,
       "check-open-brace",

--- a/tslint.json
+++ b/tslint.json
@@ -37,7 +37,6 @@
     "curly": false,
     "forin": true,
     "label-position": true,
-    "label-undefined": true,
     "no-arg": true,
     "no-bitwise": true,
     "no-conditional-assignment": true,
@@ -69,10 +68,6 @@
       true,
       "allow-null-check"
     ],
-    "use-strict": [
-      true,
-      "check-module"
-    ],
 
     "eofline": true,
     "indent": [
@@ -103,7 +98,7 @@
     "interface-name": false,
     "jsdoc-format": true,
     "no-consecutive-blank-lines": false,
-    "no-constructor-vars": false,
+    "no-parameter-properties": false,
     "one-line": [
       true,
       "check-open-brace",


### PR DESCRIPTION
The 'npm test' run was failing due to linting rules problem that I detailed in issue #146 . This PR fixes that issue and allows 'npm test' to run without failure. 