### PR TITLE
fix: Remove tslint rules breaking test run (issue #146)

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -37,7 +37,6 @@
     "curly": false,
     "forin": true,
     "label-position": true,
-    "label-undefined": true,
     "no-arg": true,
     "no-bitwise": true,
     "no-conditional-assignment": true,
@@ -69,10 +68,6 @@
       true,
       "allow-null-check"
     ],
-    "use-strict": [
-      true,
-      "check-module"
-    ],
 
     "eofline": true,
     "indent": [
@@ -103,7 +98,6 @@
     "interface-name": false,
     "jsdoc-format": true,
     "no-consecutive-blank-lines": false,
-    "no-constructor-vars": false,
     "one-line": [
       true,
       "check-open-brace",


### PR DESCRIPTION
Replacement for PR #148 that fixes issue #146 without breaking the CircleCi build. Like PR #148 this PR removes all the tslint properties causing problems with a test run (npm test). I am unsure why PR #148 was causing issues with the CircleCi build, but it worked fine for me locally -- a lame excuse, I know -;)

See issue #146 for more details on the original tslint errors that occurred when running the test script (npm test).