### PR TITLE
Add Staging Script to Webpack Configuration

### DIFF
--- a/config/github-deploy/index.js
+++ b/config/github-deploy/index.js
@@ -7,7 +7,7 @@ const SSH_REPO_NAME_RE = /Push\s*URL:\s*git@github\.com:.*\/(.*)\.git/;
 function getWebpackConfigModule() {
   if (helpers.hasProcessFlag('github-dev')) {
     return require('../webpack.dev.js');
-  } else if (helpers.hasProcessFlag('github-prod')) {
+  } else if (helpers.hasProcessFlag('github-prod') || helpers.hasProcessFlag('github-stag')) {
     return require('../webpack.prod.js');
   } else {
     throw new Error('Invalid compile option.');

--- a/config/webpack.github-deploy.js
+++ b/config/webpack.github-deploy.js
@@ -17,6 +17,13 @@ const GIT_REMOTE_NAME = 'origin';
 const COMMIT_MESSAGE = 'Updates';
 const GH_REPO_NAME = ghDeploy.getRepoName(GIT_REMOTE_NAME);
 const ENV = 'production';
+let BASEURL;
+
+if (helpers.hasProcessFlag('github-stag')) {
+  BASEURL = '/code-gov-web';
+} else {
+  BASEURL = '/';
+}
 
 const METADATA = webpackMerge(webpackConfig.metadata, {
   /**
@@ -24,7 +31,7 @@ const METADATA = webpackMerge(webpackConfig.metadata, {
    * This also means all resource URIs (CSS/Images/JS) will have this prefix added by the browser
    * unless they are absolute (start with '/'). We will handle it via `output.publicPath`
    */
-  baseUrl: '/',
+  baseUrl: BASEURL,
   ENV: ENV,
   HMR: false,
   isDevServer: false,
@@ -37,7 +44,7 @@ module.exports = function (env) {
   return webpackMerge(webpackConfig({env: ENV}), {
 
     output: {
-      publicPath: '/'
+      publicPath: BASEURL
     },
 
     plugins: [

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "build:prod": "webpack --config config/webpack.prod.js  --progress --profile --bail",
     "github-deploy": "npm run github-deploy:dev",
     "github-deploy:dev": "webpack --config config/webpack.github-deploy.js --progress --profile --env.github-dev",
+    "github-deploy:stag": "webpack --config config/webpack.github-deploy.js --progress --profile --env.github-stag",
     "github-deploy:prod": "webpack --config config/webpack.github-deploy.js --progress --profile --env.github-prod",
     "server": "npm run server:dev",
     "server:dev": "webpack-dev-server --config config/webpack.dev.js --progress --profile --watch --content-base src/",

--- a/src/index.html
+++ b/src/index.html
@@ -53,7 +53,7 @@
 
   <app>
     <div class="loading" style="background-color: #485568; bottom: 0; left: 0; position: fixed; right: 0; top: 0">
-      <img alt="United States of America Flag" width="44px" height="30px" src="assets/img/flag.svg" style="left: 50%; margin: -15px 0 0 -22px; position: absolute; top: 50%;">
+      <img alt="United States of America Flag" width="44px" height="30px" src="<%=htmlWebpackPlugin.options.metadata.baseUrl%>/assets/img/flag.svg" style="left: 50%; margin: -15px 0 0 -22px; position: absolute; top: 50%;">
       <noscript>
         <div class="no-js-content" style="left: 50%; margin-left: -20em; width: 40em; position: absolute; text-align: center; top: 50%;">
           <h1 style="color: #ffffff; font-size: 1.5em">Looks like You Don’t Have Javascript Enabled</h1>

--- a/src/styles/base/_all.scss
+++ b/src/styles/base/_all.scss
@@ -1,5 +1,5 @@
-@import 'bourbon';
-@import 'neat';
+@import '~bourbon/app/assets/stylesheets/bourbon';
+@import '~bourbon-neat/app/assets/stylesheets/neat';
 
 @import 'variables';
 @import 'animations';


### PR DESCRIPTION
Adds a script for deploying to our staging site.

* Add npm script for staging deployment
* Modify github-deploy configuration to handle staging deployment case
* Provides a temporary fix for the sassLoader not working during the Production build