### PR TITLE
Set SEO Metadata in HomeComponent

### DIFF
--- a/src/app/components/home/home.component.spec.ts
+++ b/src/app/components/home/home.component.spec.ts
@@ -5,6 +5,7 @@ import { ExternalLinkDirective } from '../../directives/external-link';
 import { HomeComponent } from './';
 import { ModalComponent } from '../modal';
 import { ModalService } from '../../services/modal';
+import { SeoService } from '../../services/seo';
 import { StateService } from '../../services/state';
 
 describe('HomeComponent', () => {
@@ -19,6 +20,7 @@ describe('HomeComponent', () => {
       ],
       providers: [
         ModalService,
+        SeoService,
         StateService
       ]
     });

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 
+import { SeoService } from '../../services/seo';
 import { StateService } from '../../services/state';
 
 @Component({
@@ -13,7 +14,11 @@ import { StateService } from '../../services/state';
 export class HomeComponent {
   url = 'https://pif.gov';
 
-  constructor(public stateService: StateService) {
+  constructor(
+    public stateService: StateService,
+    private seoService: SeoService) {
     this.stateService.set('section', 'home');
+    this.seoService.setTitle('Code.gov', false);
+    this.seoService.setMetaDescription('Code.gov is a platform designed to improve access to the federal government’s custom-developed software.');
   }
 }


### PR DESCRIPTION
Sets the Title and Description Metadata in the HomeComponent to return these values to their defaults.

* Set Title tag in HomeComponent
* Set Description tag in HomeComponent