### PR TITLE
Fix GSA Link in Footer

### DIFF
--- a/src/app/components/app/app.template.html
+++ b/src/app/components/app/app.template.html
@@ -69,7 +69,7 @@
               </a>
             </li>
             <li class="gsa">
-              <a href="//gsa.gov" target="_blank" rel="noopener">
+              <a href="//www.gsa.gov" target="_blank" rel="noopener">
                 <img src="assets/img/logos/GSA.png" alt="General Services Administration">
               </a>
             </li>


### PR DESCRIPTION
Add `www` subdomain to GSA link to fix errors with HTTPS on GSA's side.

* Add `www` subdomain to GSA link

Fixes https://github.com/presidential-innovation-fellows/code-gov-web/issues/143