### PR TITLE
Add CreateFilePlugin and Create nojekyll File for Gh Pages Deployment

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -173,9 +173,6 @@ module.exports = function (options) {
       {
         from: 'src/assets',
         to: 'assets',
-      },
-      {
-         from: 'src/meta',
       }
      ]),
 

--- a/config/webpack.github-deploy.js
+++ b/config/webpack.github-deploy.js
@@ -3,6 +3,8 @@
  */
 const helpers = require('./helpers');
 const ghDeploy = require('./github-deploy');
+const CreateFilePlugin = require('webpack-create-file-plugin');
+const CriticalCssPlugin = require('./critical-css-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin');
 const webpackMerge = require('webpack-merge'); // used to merge webpack configs
@@ -20,7 +22,7 @@ const ENV = 'production';
 let BASEURL;
 
 if (helpers.hasProcessFlag('github-stag')) {
-  BASEURL = '/code-gov-web';
+  BASEURL = '/code-gov-web/';
 } else {
   BASEURL = '/';
 }
@@ -68,6 +70,16 @@ module.exports = function (env) {
         }
       }),
 
+      new CriticalCssPlugin({
+        src: 'index.html'
+      }),
+
+      new CreateFilePlugin({
+        files: [
+          '.nojekyll'
+        ]
+      }),
+
       function() {
         this.plugin('done', function() {
           console.log('Starting deployment to GitHub.');
@@ -79,7 +91,8 @@ module.exports = function (env) {
           const options = {
             logger: logger,
             remote: GIT_REMOTE_NAME,
-            message: COMMIT_MESSAGE
+            message: COMMIT_MESSAGE,
+            dotfiles: true
           };
 
           ghpages.publish(webpackConfig({env: ENV}).output.path, options, function(err) {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "typed.js": "^1.1.1",
     "typings": "^1.3.3",
     "uswds": "^0.12.1",
+    "webpack-create-file-plugin": "^0.1.0",
     "zone.js": "~0.6.17"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes https://github.com/presidential-innovation-fellows/code-gov-web/issues/160 by adding a `nojekyll` file to the root of `dist` during deployment. GH Pages uses `jekyll` fore deployment and ignores any scripts prefixed with `vendor`.

* Add CreateFilePlugin
* Create empty `nojekyll` file for deploying to GH Pages
* Add CriticalCssPlugin to GitHub Deploy Config