### PR TITLE
Create Separate Staging Webpack Config

### DIFF
--- a/config/CNAME
+++ b/config/CNAME
@@ -1,0 +1,1 @@
+code.gov

--- a/config/github-deploy/index.js
+++ b/config/github-deploy/index.js
@@ -7,8 +7,10 @@ const SSH_REPO_NAME_RE = /Push\s*URL:\s*git@github\.com:.*\/(.*)\.git/;
 function getWebpackConfigModule() {
   if (helpers.hasProcessFlag('github-dev')) {
     return require('../webpack.dev.js');
-  } else if (helpers.hasProcessFlag('github-prod') || helpers.hasProcessFlag('github-stag')) {
+  } else if (helpers.hasProcessFlag('github-prod')) {
     return require('../webpack.prod.js');
+  } else if (helpers.hasProcessFlag('github-stag')){
+    return require('../webpack.stag.js');
   } else {
     throw new Error('Invalid compile option.');
   }

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -36,7 +36,10 @@ const METADATA = {
  * See: http://webpack.github.io/docs/configuration.html#cli
  */
 module.exports = function (options) {
-  isProd = options.env === 'production';
+  // TODO: Used by `@angularclass/hmr-loader` below. Feels bad, might
+  // want to upgrade to latest hmr-loader and pull out env dependency
+  // (or move this definition out of common)
+  isProd = ['production', 'staging'].includes(options.env);
 
   return {
 

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -21,7 +21,7 @@ const ENV = process.env.ENV = process.env.NODE_ENV = 'development';
 const HOST = process.env.HOST || 'localhost';
 const PORT = process.env.PORT || 2700;
 const HMR = helpers.hasProcessFlag('hot');
-const METADATA = webpackMerge(commonConfig({env: ENV}).metadata, {
+const METADATA = webpackMerge(commonConfig({ env: ENV }).metadata, {
   host: HOST,
   port: PORT,
   ENV: ENV,
@@ -35,7 +35,7 @@ const METADATA = webpackMerge(commonConfig({env: ENV}).metadata, {
  * See: http://webpack.github.io/docs/configuration.html#cli
  */
 module.exports = function (options) {
-  return webpackMerge(commonConfig({env: ENV}), {
+  return webpackMerge(commonConfig({ env: ENV }), {
 
     /**
      * Developer tool to enhance debugging

--- a/config/webpack.stag.js
+++ b/config/webpack.stag.js
@@ -18,13 +18,12 @@ const NormalModuleReplacementPlugin = require('webpack/lib/NormalModuleReplaceme
 const ProvidePlugin = require('webpack/lib/ProvidePlugin');
 const UglifyJsPlugin = require('webpack/lib/optimize/UglifyJsPlugin');
 const WebpackMd5Hash = require('webpack-md5-hash');
-const CopyWebpackPlugin = require('copy-webpack-plugin');
 const CriticalCssPlugin = require('./critical-css-plugin');
 
 /**
  * Webpack Constants
  */
-const ENV = process.env.NODE_ENV = process.env.ENV = 'staging';
+const ENV = process.env.NODE_ENV = process.env.ENV = 'production';
 const HOST = process.env.HOST || 'localhost';
 const PORT = process.env.PORT || 8080;
 
@@ -34,7 +33,7 @@ const METADATA = webpackMerge(commonConfig({ env: ENV }).metadata, {
   port: PORT,
   ENV: ENV,
   HMR: false,
-  gtmAuth: 'GTM-M9L9Q5'
+  gtmAuth: 'GTM-NTMZFB'
 });
 
 module.exports = function (env) {
@@ -216,16 +215,6 @@ module.exports = function (env) {
       new CriticalCssPlugin({
         src: 'index.html'
       }),
-
-      new CopyWebpackPlugin([
-       {
-         from: 'src/assets',
-         to: 'assets',
-       },
-       {
-         from: 'config/CNAME'
-       }
-      ]),
 
       /**
        * Plugin LoaderOptionsPlugin (experimental)

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "prebuild:dev": "npm run clean:dist",
     "build:dev": "webpack --config config/webpack.dev.js --progress --profile",
     "prebuild:prod": "npm run clean:dist",
+    "build:stag": "webpack --config config/webpack.stag.js  --progress --profile --bail",
     "build:prod": "webpack --config config/webpack.prod.js  --progress --profile --bail",
     "github-deploy": "npm run github-deploy:dev",
     "github-deploy:dev": "webpack --config config/webpack.github-deploy.js --progress --profile --env.github-dev",


### PR DESCRIPTION
Creates a separate Webpack config file for staging to use separate GTM codes and to copy a CNAME file to production only.

* Create staging Webpack config
* Copy CNAME file for production