### PR TITLE
perf(index): move GTM script to body and add defer attribute

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -31,16 +31,6 @@
 
   <!-- base url -->
   <base href="<%= htmlWebpackPlugin.options.metadata.baseUrl %>">
-
-  <% if (htmlWebpackPlugin.options.metadata.gtmAuth != null) { %>
-    <script>
-      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','<%=htmlWebpackPlugin.options.metadata.gtmId%>');
-    </script>
-  <% } %>
 </head>
 
 <body>
@@ -72,6 +62,14 @@
     <script src="/webpack-dev-server.js"></script>
   <% } %>
 
-
+  <% if (htmlWebpackPlugin.options.metadata.gtmAuth != null) { %>
+    <script defer>
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','<%=htmlWebpackPlugin.options.metadata.gtmId%>');
+    </script>
+  <% } %>
 </body>
 </html>


### PR DESCRIPTION
Since the script is non-essential for page rendering, it doesn't
need to be evaluated synchronously and block the rendering of
the page.