### PR TITLE
Trigger Modals for External URLs Only

### DIFF
--- a/src/app/components/explore-code/repo/repo.template.html
+++ b/src/app/components/explore-code/repo/repo.template.html
@@ -12,13 +12,13 @@
     <div class="repo-actions">
       <ul class="usa-unstyled-list">
         <li *ngIf="repo.homepage && repo.homepage != 'null'">
-          <a external-link class="usa-button" href="{{repo.homepage}}">
+          <a external-link class="usa-button" href="{{repo.homepage}}" target="_blank">
             Homepage
           </a>
         </li>
 
         <li *ngIf="repo.repoURL && repo.repoURL != 'null'">
-          <a external-link class="usa-button" href="{{ repo.repoURL }}">
+          <a external-link class="usa-button" href="{{ repo.repoURL }}" target="_blank">
             Visit Repo
           </a>
         </li>

--- a/src/app/directives/external-link/external-link.directive.spec.ts
+++ b/src/app/directives/external-link/external-link.directive.spec.ts
@@ -1,0 +1,61 @@
+import { Component, Directive } from '@angular/core';
+import { inject, TestBed } from '@angular/core/testing';
+import { Observable } from 'rxjs';
+
+import { ExternalLinkDirective } from './external-link.directive';
+import { ModalService } from '../../services/modal';
+
+
+describe('ExternalLinkDirective', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ExternalLinkDirective, TestComponent ],
+      providers: [{provide: ModalService, useClass: mockModalService}]
+    });
+
+    this.fixture = TestBed.createComponent(TestComponent);
+    this.fixture.detectChanges();
+  });
+
+  it('should trigger the ModalService when an external link is quicked', () => {
+    let modalService = TestBed.get(ModalService);
+    spyOn(modalService, 'showModal');
+    this.fixture.debugElement.nativeElement.querySelector('#ext-link').click();
+
+    expect(modalService.showModal).toHaveBeenCalled();
+  });
+
+  it('should do nothing when a .gov is clicked', () => {
+    let modalService = TestBed.get(ModalService);
+    spyOn(modalService, 'showModal');
+    this.fixture.debugElement.nativeElement.querySelector('#gov-link').click();
+
+    expect(modalService.showModal).not.toHaveBeenCalled();
+  });
+
+  it('should do nothing when a .mil is clicked', () => {
+    let modalService = TestBed.get(ModalService);
+    spyOn(modalService, 'showModal');
+    this.fixture.debugElement.nativeElement.querySelector('#mil-link').click();
+
+    expect(modalService.showModal).not.toHaveBeenCalled();
+  });
+});
+
+@Component({
+    selector: 'test',
+    template: `
+      <a external-link id="gov-link" href="https://code.gov" target="_blank">Code.gov</a>
+      <a external-link id="mil-link" href="https://code.mil" target="_blank">Code.mil</a>
+      <a external-link id="ext-link" href="https://github.com" target="_blank">GitHub</a>
+    `
+})
+
+class TestComponent {
+}
+
+class mockModalService {
+  showModal(data: any) {
+    return Observable.of({});
+  }
+}

--- a/src/app/directives/external-link/external-link.directive.ts
+++ b/src/app/directives/external-link/external-link.directive.ts
@@ -10,6 +10,7 @@ import { ModalService } from '../../services/modal';
 
 export class ExternalLinkDirective {
   modalContent: Object;
+  url: string;
 
   constructor(private el: ElementRef, private modalService: ModalService) {
     this.modalContent = {
@@ -20,9 +21,17 @@ export class ExternalLinkDirective {
     };
   }
 
+  isExternalLink(url) {
+    return !this.url.match(/(.+\.)?([^.]+)\.(?:gov|mil)$/);
+  }
+
   onClick(event: any) {
-    event.preventDefault();
-    this.modalContent['url'] = this.el.nativeElement.getAttribute('href');
-    this.modalService.showModal(this.modalContent);
+    this.url = this.el.nativeElement.getAttribute('href');
+
+    if (this.isExternalLink(this.url)) {
+      event.preventDefault();
+      this.modalContent['url'] = this.url;
+      this.modalService.showModal(this.modalContent);
+    }
   }
 }

--- a/src/app/pipes/pluralize/pluralize.pipe.ts
+++ b/src/app/pipes/pluralize/pluralize.pipe.ts
@@ -1,4 +1,4 @@
-import * as pluralize from 'pluralize';
+import * as Pluralize from 'pluralize';
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
@@ -7,6 +7,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 
 export class PluralizePipe implements PipeTransform {
   transform(value: string, arg: number): any {
+    const pluralize:any = Pluralize;
 
     return pluralize.plural(value, arg);
   }


### PR DESCRIPTION
Modifies the ExternalLinkDirective to ensure that Modals are only triggered for external URLs.

* Add conditional to check for .gov/.mil links in Modals
* Add tests for ExternalLinkDirective

Fixes https://github.com/presidential-innovation-fellows/code-gov-web/issues/169