### PR TITLE
Chore/flesh out repo component spec; add isDefinedPipe with tests; refactored repo component to use pipe

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -20,6 +20,7 @@ import { LanguageIconPipe } from './pipes/language-icon';
 import { PluralizePipe } from './pipes/pluralize';
 import { TruncatePipe } from './pipes/truncate';
 import { AppComponent } from './utils/app-components';
+import { IsDefinedPipe } from './pipes/is-defined';
 import { APP_COMPONENTS } from './utils/app-components';
 import { AgencyService, AGENCIES } from './services/agency';
 import { MobileService } from './services/mobile';
@@ -55,6 +56,7 @@ const APP_PROVIDERS = [
     ExternalLinkDirective,
     LanguageIconPipe,
     PluralizePipe,
+    IsDefinedPipe,
     ToggleMenuDirective,
     TruncatePipe
   ],

--- a/src/app/components/explore-code/repo/repo.component.spec.ts
+++ b/src/app/components/explore-code/repo/repo.component.spec.ts
@@ -1,34 +1,59 @@
-import { ActivatedRoute, RouterModule } from '@angular/router';
 import { Component } from '@angular/core';
+import { TestBed, inject, ComponentFixture } from '@angular/core/testing';
 import { HttpModule } from '@angular/http';
-import { async, fakeAsync, inject, TestBed, tick } from '@angular/core/testing';
+import { ActivatedRoute, RouterModule } from '@angular/router';
+import { Location, CommonModule } from '@angular/common';
+import { RouterTestingModule } from '@angular/router/testing';
 import { Observable } from 'rxjs/Rx';
+import { By } from '@angular/platform-browser';
 
 import { AgencyService } from '../../../services/agency';
 import { ExternalLinkDirective } from '../../../directives/external-link';
 import { RepoComponent } from './index';
 import { ReposService } from '../../../services/repos';
-import { REPOS } from '../../../services/repos';
 import { SeoService } from '../../../services/seo';
+import { LanguageIconPipe } from './../../../pipes/language-icon/language-icon.pipe';
+import { TruncatePipe } from './../../../pipes/truncate/truncate.pipe';
+import { ModalComponent } from './../../modal/modal.component';
+import { ActivityListComponent } from './../activity-list/activity-list.component';
+import { ModalService } from './../../../services/modal/modal.service';
+import { IsDefinedPipe } from './../../../pipes/is-defined/is-defined.pipe';
 
+// set test repository id used throughout to Dept of Veterans Affairs
+let id = '33202667';
+
+/**
+ * Unit tests for RepoComponent.
+ *
+ */
 describe('RepoComponent', () => {
-  let id = '33202667';
-  let fixture;
-  let repoComponent;
+  let fixture: ComponentFixture<RepoComponent>;
+  let repoComponent: RepoComponent;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [
+        CommonModule,
+        HttpModule,
+        // This hack is needed because there is a routerLink in the template
+        RouterTestingModule.withRoutes([
+         { path: 'explore-code/agencies/:id', component: DummyRoutingComponent }
+        ])
+      ],
       declarations: [
         ExternalLinkDirective,
-        RepoComponent
-      ],
-      imports: [
-        HttpModule,
-        RouterModule
+        LanguageIconPipe,
+        TruncatePipe,
+        ActivityListComponent,
+        ModalComponent,
+        RepoComponent,
+        DummyRoutingComponent,
+        IsDefinedPipe
       ],
       providers: [
         AgencyService,
         ReposService,
+        ModalService,
         SeoService,
         { provide: ActivatedRoute, useClass: MockActivatedRoute }
       ]
@@ -36,34 +61,288 @@ describe('RepoComponent', () => {
 
     fixture = TestBed.createComponent(RepoComponent);
     repoComponent = fixture.componentInstance;
+
   });
 
-  /*
-  TODO: Fix this test
-  describe('getRepo', inject([AgencyService, ReposService], (agencyService, reposService) => {
-    it('returns a valid Repo', () => {
-      spyOn(agencyService, 'getAgency');
-      spyOn(reposService, 'getJsonFile').and.returnValue(Observable.of(REPOS));
+  it('should initialize repo property when getJsonagency.id property is set',
+    inject([AgencyService, ReposService],
+      (agencyService, reposService)  => {
+    // setup dependencies
+    let agency = {id: 'VA', name: 'Department of Veterans Affairs'};
+    spyOn(agencyService, 'getAgency').and.returnValue(agency);
+    let repo = createRepository({name: 'Fake repo name'});
+    spyOn(reposService, 'getJsonFile').and.returnValue(Observable.of(repo));
 
-      console.log(repoComponent.getRepo(id));
-    }));
+    fixture.detectChanges();
+
+    expect(repoComponent.repo).toBeDefined();
+    // also checking on agency object after call to AgencyService.getAgancy()
+    expect(repoComponent.repo.agency.id).toEqual(agency.id);
+    // console.log("Agency: ", repoComponent.repo.agency);
+  }));
+
+  it('should NOT initialize repo property if id property is bogus',
+    inject([AgencyService, ReposService],
+      (agencyService, reposService)  => {
+    let agency = {id: 'VA', name: 'Department of Veterans Affairs'};
+    spyOn(agencyService, 'getAgency').and.returnValue(agency);
+    let repos = undefined;
+    spyOn(reposService, 'getJsonFile').and.returnValue(Observable.of(repos));
+    // instantiate a new RepoComponent so that ngOnInit() doesn't get called
+    let newRepoComponent = new RepoComponent(null, agencyService, reposService, null);
+
+    // call getRepo() that invokes reposService.getJsonFile()
+    newRepoComponent.getRepo('');
+
+    expect(newRepoComponent.repo).toBeUndefined();
+  }));
+
+  it('should call seoService.setMetaDescription() when repository is returned ' +
+    ' when reposService.getJsonFile() returns a repository' ,
+    inject([AgencyService, ReposService, SeoService],
+      (agencyService, reposService, seoService)  => {
+    let agency = {id: 'VA', name: 'Department of Veterans Affairs'};
+    spyOn(agencyService, 'getAgency').and.returnValue(agency);
+    let repo = createRepository({name: 'Another Fake repo name'});
+    spyOn(reposService, 'getJsonFile').and.returnValue(Observable.of(repo));
+    spyOn(seoService, 'setMetaDescription');
+
+    fixture.detectChanges();
+
+    expect(repoComponent.repo).toBeDefined();
+    expect(seoService.setMetaDescription).toHaveBeenCalled();
   }));
 
 
-  describe('destroy', () => {
-    it('should unsubscribe from router events on destroy', () => {
-      this.fixture.detectChanges();
-      spyOn(repoComponent.eventSub, 'unsubscribe');
-      this.fixture.destroy()
-      expect(repoComponent.eventSub.unsubscribe).toHaveBeenCalled();
-    });
-  });
-  */
+  // describe('destroy', () => {
+  //   it('should unsubscribe from router events on destroy', () => {
+  //     this.fixture.detectChanges();
+  //     spyOn(repoComponent.eventSub, 'unsubscribe');
+  //     this.fixture.destroy()
+  //     expect(repoComponent.eventSub.unsubscribe).toHaveBeenCalled();
+  //   });
+  // });
+
+  it('should display repoUrl in template if repo.repoUrl property is set',
+    inject([AgencyService, ReposService, SeoService],
+      (agencyService, reposService, seoService)  => {
+    let agency = {id: 'VA', name: 'Department of Veterans Affairs'};
+    spyOn(agencyService, 'getAgency').and.returnValue(agency);
+    const repoURL = 'http://www.github.com/foobar/';
+    let repo = createRepository(
+      {name: 'A Fake repo name to show repo',
+      repoURL: repoURL, homepage: 'http://code.gov/foobar/' });
+    spyOn(reposService, 'getJsonFile').and.returnValue(Observable.of(repo));
+
+    fixture.detectChanges();
+
+    let anchors = fixture.nativeElement.querySelectorAll('.usa-button');
+    // console.log('Anchors: ', anchors);
+
+    // 2nd child anchor is the repoURL (first one is homepage)
+    expect(anchors[1].href).toBe(repoURL);
+  }));
+
+  it('should display repository name in template if repo.name property is defined',
+    inject([AgencyService, ReposService, SeoService],
+      (agencyService, reposService, seoService)  => {
+        setupRepoPropertyTest(agencyService, reposService, seoService,
+          {name: 'VA REPO'});
+
+        fixture.detectChanges();
+
+        let el = fixture.nativeElement.querySelector('h1');
+        // expect name to be disolayed
+        expect(el.textContent).toBeDefined();
+      }
+  ));
+
+/******* Test repo.description  ****/
+
+  it('should NOT display repository description in template if repo.description property is undefined',
+    inject([AgencyService, ReposService, SeoService],
+      (agencyService, reposService, seoService)  => {
+        setupRepoPropertyTest(agencyService, reposService, seoService,
+          {description: undefined});
+
+        fixture.detectChanges();
+
+        let div = fixture.nativeElement.querySelector('.repo-header-container');
+        expect(div.children[2]).toBeUndefined();
+      }
+  ));
+
+
+  it('should NOT display repository description in template if repo.description property is null',
+    inject([AgencyService, ReposService, SeoService],
+      (agencyService, reposService, seoService)  => {
+        setupRepoPropertyTest(agencyService, reposService, seoService,
+          {description: null});
+
+        fixture.detectChanges();
+
+        let div = fixture.nativeElement.querySelector('.repo-header-container');
+        expect(div.children[2]).toBeUndefined();
+      }
+  ));
+
+  it('should display repository description in template if repo.description property is defined',
+    inject([AgencyService, ReposService, SeoService],
+      (agencyService, reposService, seoService)  => {
+        setupRepoPropertyTest(agencyService, reposService, seoService,
+          {description: 'REPO DESC'});
+
+        fixture.detectChanges();
+
+        let div = fixture.nativeElement.querySelector('.repo-header-container');
+        expect(div.children[2]).toBeDefined();
+      }
+  ));
+
+
+/******* Test repo.homepage  ****/
+
+  it('should NOT display repository homepage in template if repo.homepage property is undefined',
+    inject([AgencyService, ReposService, SeoService],
+      (agencyService, reposService, seoService)  => {
+        setupRepoPropertyTest(agencyService, reposService, seoService,
+          {homepage: undefined});
+
+        fixture.detectChanges();
+
+        let parent = fixture.nativeElement.querySelector('.usa-unstyled-list');
+        expect(parent.children[0]).toBeUndefined();
+      }
+  ));
+
+
+  it('should NOT display repository homepage in template if repo.homepage property is null',
+    inject([AgencyService, ReposService, SeoService],
+      (agencyService, reposService, seoService)  => {
+        setupRepoPropertyTest(agencyService, reposService, seoService,
+          {homepage: null});
+
+        fixture.detectChanges();
+
+        let parent = fixture.nativeElement.querySelector('.usa-unstyled-list');
+        expect(parent.children[0]).toBeUndefined();
+      }
+  ));
+
+  it('should display repository homepage in template if repo.homepage property is defined',
+    inject([AgencyService, ReposService, SeoService],
+      (agencyService, reposService, seoService)  => {
+        setupRepoPropertyTest(agencyService, reposService, seoService,
+          {homepage: 'http://code.gov/'});
+
+        fixture.detectChanges();
+
+        let parent = fixture.nativeElement.querySelector('.usa-unstyled-list');
+
+        expect(parent.children[0].children[0]).toBeDefined();
+      }
+  ));
+
+/******* Test repo.repoUrl  ****/
+
+  it('should NOT display repository url in template if repo.repoURL property is undefined',
+    inject([AgencyService, ReposService, SeoService],
+      (agencyService, reposService, seoService)  => {
+        setupRepoPropertyTest(agencyService, reposService, seoService,
+          {repoURL: undefined, homepage: 'http://foo.bar'});
+
+        fixture.detectChanges();
+
+        let parent = fixture.nativeElement.querySelector('.usa-unstyled-list');
+
+        expect(parent.children[1]).toBeUndefined();
+      }
+  ));
+
+
+  it('should NOT display repository Url in template if repo.repoURL property is null',
+    inject([AgencyService, ReposService, SeoService],
+      (agencyService, reposService, seoService)  => {
+        setupRepoPropertyTest(agencyService, reposService, seoService,
+          {repoURL: null, homepage: 'http://foo.bar'});
+
+        fixture.detectChanges();
+
+        let parent = fixture.nativeElement.querySelector('.usa-unstyled-list');
+        // console.log('PARENT: ', parent);
+        expect(parent.children[1]).toBeUndefined();
+      }
+  ));
+
+  it('should display repository repoUrl in template if repo.repoURL property is defined',
+    inject([AgencyService, ReposService, SeoService],
+      (agencyService, reposService, seoService)  => {
+        setupRepoPropertyTest(agencyService, reposService, seoService,
+          {repoURL: 'http://code.gov/repo', homepage: undefined});
+
+        fixture.detectChanges();
+
+        let parent = fixture.nativeElement.querySelector('.usa-unstyled-list');
+        // console.log('PARENT: ', parent);
+
+        expect(parent.children[0]).toBeDefined();
+      }
+  ));
 });
 
+/**
+ * Interface for repository properties that we are testing.
+ * All properties are optional since we are teasting each one in isolation.
+ */
+interface RepoProps {
+  name?: string;
+  description?: string;
+  homepage?: string;
+  repoURL?: string;
+}
+
+/**
+ *  Creates and populate a repository object for use in tests
+ * using the RepoProps interface for type safety.
+ */
+export function createRepository(repoProps: RepoProps) {
+  return {
+      repos: [
+        { repoID : id, name: repoProps.name, description: repoProps.description,
+          codeLanguage: [{language: 'JavaScript'}], agency: 'VA',
+          homepage: repoProps.homepage, repoURL: repoProps.repoURL }
+        ]
+    };
+}
+
+/**
+ * Sets up a test of repository properties, by creating agency
+ * and repostory data structures in addition to mocking
+ * RepoComponent dependencies.
+ */
+export function setupRepoPropertyTest(
+  agencyService: AgencyService, reposService: ReposService,
+  seoService: SeoService, repoProps: RepoProps) {
+    let agency = {id: 'VA', name: 'Department of Veterans Affairs'};
+    spyOn(agencyService, 'getAgency').and.returnValue(agency);
+    // set up repository
+    const FAKE_REPO = createRepository(repoProps);
+    spyOn(reposService, 'getJsonFile').and.returnValue(Observable.of(FAKE_REPO));
+
+}
+
+/**
+ * Mock route
+ */
 class MockActivatedRoute extends ActivatedRoute {
   constructor() {
     super();
-    this.params = Observable.of({id: '123456'});
+    this.params = Observable.of({id: id});
   }
+}
+
+@Component({
+  template: ''
+})
+class DummyRoutingComponent {
 }

--- a/src/app/components/explore-code/repo/repo.component.spec.ts
+++ b/src/app/components/explore-code/repo/repo.component.spec.ts
@@ -114,15 +114,6 @@ describe('RepoComponent', () => {
   }));
 
 
-  // describe('destroy', () => {
-  //   it('should unsubscribe from router events on destroy', () => {
-  //     this.fixture.detectChanges();
-  //     spyOn(repoComponent.eventSub, 'unsubscribe');
-  //     this.fixture.destroy()
-  //     expect(repoComponent.eventSub.unsubscribe).toHaveBeenCalled();
-  //   });
-  // });
-
   it('should display repoUrl in template if repo.repoUrl property is set',
     inject([AgencyService, ReposService, SeoService],
       (agencyService, reposService, seoService)  => {
@@ -288,6 +279,16 @@ describe('RepoComponent', () => {
         expect(parent.children[0]).toBeDefined();
       }
   ));
+
+  describe('ngOnDestroy()', () => {
+    it('should unsubscribe from router event subscription on destroy', () => {
+      fixture.detectChanges();
+      spyOn(repoComponent.eventSub, 'unsubscribe');
+      fixture.destroy()
+      expect(repoComponent.eventSub.unsubscribe).toHaveBeenCalled();
+    });
+  });
+
 });
 
 /**

--- a/src/app/components/explore-code/repo/repo.component.spec.ts
+++ b/src/app/components/explore-code/repo/repo.component.spec.ts
@@ -150,7 +150,8 @@ describe('RepoComponent', () => {
 
 /******* Test repo.description  ****/
 
-  it('should NOT display repository description in template if repo.description property is undefined',
+  it('should NOT display repository description in template if repo.description '
+    + 'property is undefined',
     inject([AgencyService, ReposService, SeoService],
       (agencyService, reposService, seoService)  => {
         setupRepoPropertyTest(agencyService, reposService, seoService,
@@ -284,7 +285,7 @@ describe('RepoComponent', () => {
     it('should unsubscribe from router event subscription on destroy', () => {
       fixture.detectChanges();
       spyOn(repoComponent.eventSub, 'unsubscribe');
-      fixture.destroy()
+      fixture.destroy();
       expect(repoComponent.eventSub.unsubscribe).toHaveBeenCalled();
     });
   });

--- a/src/app/components/explore-code/repo/repo.component.ts
+++ b/src/app/components/explore-code/repo/repo.component.ts
@@ -49,7 +49,7 @@ export class RepoComponent implements OnInit, OnDestroy {
           this.seoService.setMetaDescription(this.repo.description);
           this.seoService.setMetaRobots('Index, Follow');
         } else {
-          console.log('Error.');
+          console.log('Error. Source code repositories not found');
         }
     });
   }

--- a/src/app/components/explore-code/repo/repo.template.html
+++ b/src/app/components/explore-code/repo/repo.template.html
@@ -7,18 +7,18 @@
         </a>
       </h3>
       <h1>{{ repo.name }}</h1>
-      <p *ngIf="repo.description && repo.description != 'null' && repo.description != 'null '">{{ repo.description }}</p>
+      <p *ngIf="repo.description | isdefined">{{ repo.description }}</p>
     </div>
     <div class="repo-actions">
       <ul class="usa-unstyled-list">
-        <li *ngIf="repo.homepage && repo.homepage != 'null'">
-          <a external-link class="usa-button" href="{{repo.homepage}}" target="_blank">
+        <li *ngIf="repo.homepage | isdefined">
+          <a external-link class="usa-button" href="{{repo.homepage}}">
             Homepage
           </a>
         </li>
 
-        <li *ngIf="repo.repoURL && repo.repoURL != 'null'">
-          <a external-link class="usa-button" href="{{ repo.repoURL }}" target="_blank">
+        <li *ngIf="repo.repoURL | isdefined">
+          <a external-link class="usa-button" href="{{ repo.repoURL }}">
             Visit Repo
           </a>
         </li>
@@ -31,7 +31,7 @@
       <h2>Highlights</h2>
       <ul class="usa-unstyled-list repo-features-list">
         <li class="repo-language usa-width-one-half">
-          <div *ngIf="repo.codeLanguage">
+          <div *ngIf="repo.codeLanguage | isdefined">
             <div *ngFor="let language of repo.codeLanguage" class="feature-icon">
               <i class="devicons devicons-{{language.language | lowercase | languageIcon }}">
               </i>
@@ -44,7 +44,7 @@
               </span>
             </p>
           </div>
-          <div *ngIf="!repo.codeLanguage">
+          <div *ngIf="!repo.codeLanguage | isdefined">
             <div class="feature-icon">
               <i class="fa fa-question"></i>
             </div>
@@ -56,7 +56,7 @@
           </div>
         </li>
         <li class="repo-license usa-width-one-half">
-          <div *ngIf="repo.license && repo.license_name">
+          <div *ngIf="repo.license && repo.license_name | isdefined">
             <div class="feature-icon">
               <i class="fa fa-file-text-o "></i>
             </div>

--- a/src/app/pipes/is-defined/index.ts
+++ b/src/app/pipes/is-defined/index.ts
@@ -1,0 +1,1 @@
+export * from './is-defined.pipe';

--- a/src/app/pipes/is-defined/is-defined.pipe.spec.ts
+++ b/src/app/pipes/is-defined/is-defined.pipe.spec.ts
@@ -243,6 +243,7 @@ describe('IsDefinedPipe', () => {
             // console.log('actual value', actual);
 
             // actual is '0' string, so we use == comparison
+            // tslint:disable-next-line: triple-equals
             expect(actual == expected).toBeTruthy();
         });
 

--- a/src/app/pipes/is-defined/is-defined.pipe.spec.ts
+++ b/src/app/pipes/is-defined/is-defined.pipe.spec.ts
@@ -298,6 +298,18 @@ describe('IsDefinedPipe', () => {
 
             expect(el).toBeNull();
         });
+        it('should display text when value is expression evaluating to true', () => {
+            let expected = true ||  false;
+            testComponent.setValue(expected);
+
+            fixture.detectChanges();
+
+            let actual = fixture.nativeElement.querySelector('h1').innerText;
+            // console.log('actual value', actual);
+
+            expect(actual).toEqual('true');
+        });
+
     });
 
 });

--- a/src/app/pipes/is-defined/is-defined.pipe.spec.ts
+++ b/src/app/pipes/is-defined/is-defined.pipe.spec.ts
@@ -1,0 +1,361 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { IsDefinedPipe } from './is-defined.pipe';
+import { Pipe, PipeTransform } from '@angular/core';
+
+
+/**
+ * Unit tests for IsDefinedPipe including tests for
+ * IsDefinedPipe.transform() and tests where the pipe
+ * is integrated into a template.
+ */
+describe('IsDefinedPipe', () => {
+    describe('IsDefinedPipe.transform() called', () => {
+        let pipe: IsDefinedPipe;
+        beforeEach(() => {
+            pipe = new IsDefinedPipe();
+        });
+
+        it('should return true for a defined string input value', () => {
+            let value = 'Foobar';
+
+            let actual = pipe.transform(value);
+
+            expect(actual).toBeTruthy();
+        });
+
+        it('should return true for a defined object input value', () => {
+            let value = {id: 1, name: 'Foobar'};
+
+            let actual = pipe.transform(value);
+
+            expect(actual).toBeTruthy();
+        });
+
+        it('should return false for a null input value', () => {
+            let value = null;
+
+            let actual = pipe.transform(value);
+
+            expect(actual).toBeFalsy();
+        });
+
+        it('should return false for a "null" string input value', () => {
+            let value = 'null';
+
+            let actual = pipe.transform(value);
+
+            expect(actual).toBeFalsy();
+        });
+
+        it('should return false for a "null" string input value containg spaces', () => {
+            let value = ' null  ';
+
+            let actual = pipe.transform(value);
+
+            expect(actual).toBeFalsy();
+        });
+
+
+        it('should return false for a undefined input value', () => {
+            let value = undefined;
+
+            let actual = pipe.transform(value);
+
+            expect(actual).toBeFalsy();
+        });
+
+        it('should return false for an empty string input value', () => {
+            let value = '';
+
+            let actual = pipe.transform(value);
+
+            expect(actual).toBeFalsy();
+        });
+
+        it('should return false for an empty string containing spaces input value', () => {
+            let value = ' ';
+
+            let actual = pipe.transform(value);
+
+            expect(actual).toBeFalsy();
+        });
+
+        it('should return true for a positive number type input value', () => {
+            let value = 12345;
+
+            let actual = pipe.transform(value);
+
+            expect(actual).toBeTruthy();
+        });
+
+        it('should return true for a negative number type input value', () => {
+            let value = -12345;
+
+            let actual = pipe.transform(value);
+
+            expect(actual).toBeTruthy();
+        });
+
+        it('should return true for zero number type input value', () => {
+            let value = 0;
+
+            let actual = pipe.transform(value);
+
+            expect(actual).toBeTruthy();
+        });
+
+        it('should return true for a Number.MAX_VALUE input value', () => {
+            let value = Number.MAX_VALUE;
+
+            let actual = pipe.transform(value);
+
+            expect(actual).toBeTruthy();
+        });
+
+        it('should return true for a Number.MIN_VALUE input value', () => {
+            let value = Number.MIN_VALUE;
+
+            let actual = pipe.transform(value);
+
+            expect(actual).toBeTruthy();
+        });
+
+        it('should return false for a Number.NaN input value', () => {
+            let value = Number.NaN;
+
+            let actual = pipe.transform(value);
+
+            expect(actual).toBeFalsy();
+        });
+
+        it('should return true for if input value is a boolean true', () => {
+            let value = true;
+
+            let actual = pipe.transform(value);
+
+            expect(actual).toBeTruthy();
+        });
+
+        it('should return false for if input value is a boolean false', () => {
+            let value = false;
+
+            let actual = pipe.transform(value);
+
+            expect(actual).toBeFalsy();
+        });
+
+    });
+
+    describe('IsDefinedPipe integrated in a template', () => {
+        let fixture: ComponentFixture<TestIsDefinedPipeComponent>;
+        let testComponent: TestIsDefinedPipeComponent;
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                imports: [CommonModule],
+                declarations: [
+                    IsDefinedPipe,
+                    TestIsDefinedPipeComponent,
+                    TestIsDefinedPipeWithObjectComponent,
+                    TestIsNotDefinedPipeComponent,
+                    TestIsDefinedWithExpressionPipeComponent
+                    ],
+                providers: []
+            });
+            fixture = TestBed.createComponent(TestIsDefinedPipeComponent);
+            testComponent = fixture.componentInstance;
+        });
+
+        it('should display text when value is defined string', () => {
+            let expected = 'Foobar';
+            testComponent.setValue(expected);
+
+            fixture.detectChanges();
+
+            let actual = fixture.nativeElement.querySelector('h1').innerText;
+            // console.log('actual value', actual);
+
+            expect(actual).toEqual(expected);
+        });
+
+        it('should display text when value is defined object', () => {
+            // use TestIsDefinedPipeWithObjectComponent in this test
+            let objFixture: ComponentFixture<TestIsDefinedPipeWithObjectComponent>
+                = TestBed.createComponent(TestIsDefinedPipeWithObjectComponent);
+            let testObjComponent: TestIsDefinedPipeWithObjectComponent
+                = objFixture.componentInstance;
+            let expected: TestObject = {id: 3, name: 'Foobar'};
+            testObjComponent.setValue(expected);
+
+            objFixture.detectChanges();
+
+            let actual = objFixture.nativeElement.querySelector('h1').innerText;
+            // console.log('actual value', actual);
+
+            expect(actual).toEqual(expected.name);
+        });
+
+
+        it('should not display text when value is undefined', () => {
+            let expected = undefined;
+            testComponent.setValue(expected);
+
+            fixture.detectChanges();
+
+            let el = fixture.nativeElement.querySelector('h1');
+            // console.log('actual value', el);
+
+            expect(el).toBeNull();
+        });
+
+        it('should not display text when value is null', () => {
+            let expected = null;
+            testComponent.setValue(expected);
+
+            fixture.detectChanges();
+
+            let el = fixture.nativeElement.querySelector('h1');
+            // console.log('actual value', el);
+
+            expect(el).toBeNull();
+        });
+
+        it('should not display text when value is string with "null" value', () => {
+            let expected = 'null';
+            testComponent.setValue(expected);
+
+            fixture.detectChanges();
+
+            let el = fixture.nativeElement.querySelector('h1');
+            // console.log('actual value', el);
+
+            expect(el).toBeNull();
+        });
+
+        it('should display text when value is zero', () => {
+            let expected = 0;
+            testComponent.setValue(expected);
+
+            fixture.detectChanges();
+
+            let actual = fixture.nativeElement.querySelector('h1').textContent;
+            // console.log('actual value', actual);
+
+            // actual is '0' string, so we use == comparison
+            expect(actual == expected).toBeTruthy();
+        });
+
+        it('should display text when !value is undefined', () => {
+            // note that !undefined === true
+            let objFixture: ComponentFixture<TestIsNotDefinedPipeComponent>
+                = TestBed.createComponent(TestIsNotDefinedPipeComponent);
+            let testObjComponent: TestIsNotDefinedPipeComponent
+                = objFixture.componentInstance;
+            let val = undefined;
+            testObjComponent.setValue(val);
+
+            objFixture.detectChanges();
+
+            let actual = objFixture.nativeElement.querySelector('h1').innerText;
+            // console.log('actual value', actual);
+
+            expect(actual).toEqual('Undefined');
+        });
+
+        it('should display text when all values in "&&" expression is defined', () => {
+            let objFixture: ComponentFixture<TestIsDefinedWithExpressionPipeComponent>
+                = TestBed.createComponent(TestIsDefinedWithExpressionPipeComponent);
+            let testObjComponent: TestIsDefinedWithExpressionPipeComponent
+                = objFixture.componentInstance;
+            let val1 = 99;
+            testObjComponent.setValue1(val1);
+            let val2 = 'val2 defined';
+            testObjComponent.setValue2(val2);
+
+            objFixture.detectChanges();
+
+            let actual = objFixture.nativeElement.querySelector('h1').innerText;
+            // console.log('actual value', actual);
+
+            expect(actual).toEqual('Two Values Defined');
+        });
+
+        it('should NOT display text when one value in "&&" expression is undefined', () => {
+            let objFixture: ComponentFixture<TestIsDefinedWithExpressionPipeComponent>
+                = TestBed.createComponent(TestIsDefinedWithExpressionPipeComponent);
+            let testObjComponent: TestIsDefinedWithExpressionPipeComponent
+                = objFixture.componentInstance;
+            let val1 = 99;
+            testObjComponent.setValue1(val1);
+            let val2 = undefined;
+            testObjComponent.setValue2(val2);
+
+            objFixture.detectChanges();
+
+            let el = objFixture.nativeElement.querySelector('h1');
+            // console.log('actual value', el);
+
+            expect(el).toBeNull();
+        });
+    });
+
+});
+
+@Component({
+    selector: '',
+    template: `<h1 *ngIf="value | isdefined">{{value}}</h1>`
+})
+class TestIsDefinedPipeComponent {
+    private value: any;
+
+    setValue(val: any) {
+        this.value = val;
+    }
+}
+
+interface TestObject {
+    id: number;
+    name: string;
+}
+
+@Component({
+    selector: '',
+    template: `<h1 *ngIf="value | isdefined">{{value.name}}</h1>`
+})
+class TestIsDefinedPipeWithObjectComponent {
+    private value: TestObject;
+
+    setValue(val: TestObject) {
+        this.value = val;
+    }
+}
+
+@Component({
+    selector: '',
+    template: `<h1 *ngIf="!value | isdefined">Undefined</h1>`
+})
+class TestIsNotDefinedPipeComponent {
+    private value: any;
+
+    setValue(val: any) {
+        this.value = val;
+    }
+}
+
+@Component({
+    selector: '',
+    template: `<h1 *ngIf="value1 && value2 | isdefined">Two Values Defined</h1>`
+})
+class TestIsDefinedWithExpressionPipeComponent {
+    private value1: any;
+    private value2: any;
+
+    setValue1(val: any) {
+        this.value1 = val;
+    }
+
+    setValue2(val: any) {
+        this.value2 = val;
+    }
+}

--- a/src/app/pipes/is-defined/is-defined.pipe.ts
+++ b/src/app/pipes/is-defined/is-defined.pipe.ts
@@ -6,11 +6,11 @@ import { Pipe, PipeTransform } from '@angular/core';
  * transform() method.
  *
  * If the transform() argument is defined, then the method
- * will return true. However, if the argument to tranform()
+ * will return true. However, if the argument to transform()
  * is a string and it can be trimmed to an empty string,
  * then false is returned. Also, if the argument to tranform()
- * is a string with a trimmed value of 'null', then false
- * is returned.
+ * is a string with a trimmed value of 'null' or 'undefined;,
+ * then false is returned.
  *
  */
 @Pipe({
@@ -25,7 +25,7 @@ export class IsDefinedPipe implements PipeTransform {
      * @param args - Not used by this pipe
      * @return true if value is defined or if a string
      * that the trimmed value is not an empty string
-     * or one whose value is 'null', otherwise false.
+     * or one whose value is 'null' or 'undefined', otherwise false.
      */
     transform(value: any, args?: any[]): any {
       if (typeof value === 'string') {

--- a/src/app/pipes/is-defined/is-defined.pipe.ts
+++ b/src/app/pipes/is-defined/is-defined.pipe.ts
@@ -28,30 +28,38 @@ export class IsDefinedPipe implements PipeTransform {
      * or one whose value is 'null', otherwise false.
      */
     transform(value: any, args?: any[]): any {
-        if (typeof value === 'string') {
-            value = value.trim();
-            if (value === 'null') {
-                return false;
-            } else if (value === 'undefined') {
-                return false;
-            } else {
-                if (value) {
-                    return true;
-                }
-            }
+      if (typeof value === 'string') {
+          return this.isDefinedString(value);
       } else if (typeof value === 'number') {
-          // in this case, zero is truthy, since in JS, zero is falsy
-          if ( value === 0 ) {
-              return true;
-          } else {
-              if (value) {
-                  return true;
-              }
-          }
+          return this.isDefinedNumber(value);
       } else if (value) {
           return true;
       }
-
       return false;
+    }
+
+    private isDefinedString(value: string): boolean {
+        value = value.trim();
+        if (value === 'null') {
+            return false;
+        } else if (value === 'undefined') {
+            return false;
+        } else {
+            if (value) {
+                return true;
+            }
+        }
+    }
+
+    private isDefinedNumber(value: number): boolean {
+        // In this case, zero is truthy,
+        //  since in JavaScript, zero is false/falsy
+        if ( value === 0 ) {
+            return true;
+        } else {
+            if (value) {
+                return true;
+            }
+        }
     }
 }

--- a/src/app/pipes/is-defined/is-defined.pipe.ts
+++ b/src/app/pipes/is-defined/is-defined.pipe.ts
@@ -1,0 +1,57 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+/**
+ * Pipe used in boolean expressions in a template to signify
+ * that the pipe value argument is defined using the
+ * transform() method.
+ *
+ * If the transform() argument is defined, then the method
+ * will return true. However, if the argument to tranform()
+ * is a string and it can be trimmed to an empty string,
+ * then false is returned. Also, if the argument to tranform()
+ * is a string with a trimmed value of 'null', then false
+ * is returned.
+ *
+ */
+@Pipe({
+    name: 'isdefined'
+})
+export class IsDefinedPipe implements PipeTransform {
+    /**
+     * Test method used to implement PipeTransform
+     * where the actual define check is done.
+     *
+     * @param value - The value to check if it is a defined value
+     * @param args - Not used by this pipe
+     * @return true if value is defined or if a string
+     * that the trimmed value is not an empty string
+     * or one whose value is 'null', otherwise false.
+     */
+    transform(value: any, args?: any[]): any {
+        if (typeof value === 'string') {
+            value = value.trim();
+            if (value === 'null') {
+                return false;
+            } else if (value === 'undefined') {
+                return false;
+            } else {
+                if (value) {
+                    return true;
+                }
+            }
+      } else if (typeof value === 'number') {
+          // in this case, zero is truthy, since in JS, zero is falsy
+          if ( value === 0 ) {
+              return true;
+          } else {
+              if (value) {
+                  return true;
+              }
+          }
+      } else if (value) {
+          return true;
+      }
+
+      return false;
+    }
+}


### PR DESCRIPTION
This PR is for issue #175. It involved fleshing out the repo component spec. Based on and supported by the testing, the spec component template was refactored to simplify *ngIf expressions which involved creating an isDefinedPipe (is-defined.pipe.ts). Also included is a comprehensive set of unit tests for the isDefinedPipe (is-defined.pipe.spec.ts).

It should be noted that the isDefinedPipe pipe considers the strings 'null' and 'undefined' as undefined (the pipe returns false). The pipe also trims strings so that a string only containing spaces is trimmed to a blank string and is considered undefined. 