### PR TITLE
Add Angularitics2 For Tracking Page Views and Events

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -26,7 +26,7 @@ const METADATA = webpackMerge(commonConfig({ env: ENV }).metadata, {
   port: PORT,
   ENV: ENV,
   HMR: HMR,
-  gtmId: 'GTM-MSJCVSA'
+  gtmAuth: 'GTM-MSJCVS'
 });
 
 /**

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@angularclass/conventions-loader": "^1.0.2",
     "@angularclass/hmr": "~1.2.0",
     "@angularclass/hmr-loader": "~3.0.2",
+    "angulartics2": "^1.4.3",
     "assets-webpack-plugin": "^3.4.0",
     "bourbon": "^4.2.7",
     "bourbon-neat": "^1.8.0",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -7,6 +7,8 @@ import { removeNgStyles, createNewHosts } from '@angularclass/hmr';
 import { AuthHttp, AuthConfig, AUTH_PROVIDERS, provideAuth} from 'angular2-jwt';
 import { HashLocationStrategy, LocationStrategy } from '@angular/common';
 
+import { Angulartics2Module, Angulartics2GoogleTagManager } from 'angulartics2';
+
 /*
  * Platform and Environment providers/directives/pipes
  */
@@ -45,6 +47,7 @@ const APP_PROVIDERS = [
  */
 @NgModule({
   imports: [ // import Angular's modules
+    Angulartics2Module.forRoot(),
     BrowserModule,
     FormsModule,
     ReactiveFormsModule,
@@ -63,7 +66,8 @@ const APP_PROVIDERS = [
   providers: [ // expose our Services and Providers into Angular's dependency injection
     ENV_PROVIDERS,
     {provide: LocationStrategy, useClass: HashLocationStrategy},
-    APP_PROVIDERS
+    APP_PROVIDERS,
+    Angulartics2GoogleTagManager
   ],
   bootstrap: [ AppComponent ]
 })

--- a/src/app/components/app/app.component.spec.ts
+++ b/src/app/components/app/app.component.spec.ts
@@ -1,3 +1,8 @@
+import {
+  Angulartics2,
+  Angulartics2GoogleTagManager,
+  Angulartics2Module
+} from 'angulartics2';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { Component } from '@angular/core';
 import { APP_BASE_HREF } from '@angular/common';
@@ -26,11 +31,14 @@ describe('AgencyComponent', () => {
         TruncatePipe
       ],
       imports: [
+        Angulartics2Module.forRoot(),
         HttpModule,
         RouterModule.forRoot([])
       ],
       providers: [
         AgencyService,
+        Angulartics2,
+        Angulartics2GoogleTagManager,
         ReposService,
         SeoService,
         StateService,

--- a/src/app/components/app/app.component.ts
+++ b/src/app/components/app/app.component.ts
@@ -1,3 +1,4 @@
+import { Angulartics2, Angulartics2GoogleTagManager } from 'angulartics2';
 import { Component, ViewEncapsulation, OnInit, OnDestroy } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
 import { Subscription } from 'rxjs/Subscription';
@@ -15,6 +16,8 @@ export class AppComponent implements OnInit, OnDestroy {
   eventSub: Subscription;
 
   constructor(
+    private angulartics2: Angulartics2,
+    angulartics2Gtm: Angulartics2GoogleTagManager,
     private router: Router,
     public stateService: StateService
   ) {}


### PR DESCRIPTION
Adds Angularitics2 package for enabling event tracking with Google Tag Manager.

* Add Angularitics2 package
* Add Angularitics2 to AppModule and AppComponent for automatic Page View tracking