### PR TITLE
Add Event Tracking to External Links and Modals

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -7,6 +7,7 @@ import { removeNgStyles, createNewHosts } from '@angularclass/hmr';
 import { AuthHttp, AuthConfig, AUTH_PROVIDERS, provideAuth} from 'angular2-jwt';
 import { HashLocationStrategy, LocationStrategy } from '@angular/common';
 
+import { Angulartics2On } from 'angulartics2';
 import { Angulartics2Module, Angulartics2GoogleTagManager } from 'angulartics2';
 
 /*

--- a/src/app/components/app/app.component.spec.ts
+++ b/src/app/components/app/app.component.spec.ts
@@ -1,13 +1,14 @@
-import {
-  Angulartics2,
-  Angulartics2GoogleTagManager,
-  Angulartics2Module
-} from 'angulartics2';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { Component } from '@angular/core';
 import { APP_BASE_HREF } from '@angular/common';
 import { HttpModule } from '@angular/http';
 import { inject, TestBed } from '@angular/core/testing';
+
+import {
+  Angulartics2,
+  Angulartics2GoogleTagManager,
+  Angulartics2Module
+} from 'angulartics2';
 import { Observable } from 'rxjs/Rx';
 
 import { AppComponent } from './index';

--- a/src/app/components/app/app.component.ts
+++ b/src/app/components/app/app.component.ts
@@ -17,7 +17,7 @@ export class AppComponent implements OnInit, OnDestroy {
 
   constructor(
     private angulartics2: Angulartics2,
-    angulartics2Gtm: Angulartics2GoogleTagManager,
+    private angulartics2Gtm: Angulartics2GoogleTagManager,
     private router: Router,
     public stateService: StateService
   ) {}

--- a/src/app/components/explore-code/agency/agency.component.spec.ts
+++ b/src/app/components/explore-code/agency/agency.component.spec.ts
@@ -2,6 +2,7 @@ import { ActivatedRoute, RouterModule } from '@angular/router';
 import { Component } from '@angular/core';
 import { HttpModule } from '@angular/http';
 import { inject, TestBed } from '@angular/core/testing';
+
 import { Observable } from 'rxjs/Rx';
 
 import { AgencyComponent } from './index';

--- a/src/app/components/explore-code/repo/repo.component.spec.ts
+++ b/src/app/components/explore-code/repo/repo.component.spec.ts
@@ -4,8 +4,10 @@ import { HttpModule } from '@angular/http';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { Location, CommonModule } from '@angular/common';
 import { RouterTestingModule } from '@angular/router/testing';
-import { Observable } from 'rxjs/Rx';
 import { By } from '@angular/platform-browser';
+
+import { Angulartics2, Angulartics2Module } from 'angulartics2';
+import { Observable } from 'rxjs/Rx';
 
 import { AgencyService } from '../../../services/agency';
 import { ExternalLinkDirective } from '../../../directives/external-link';
@@ -33,6 +35,7 @@ describe('RepoComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
+        Angulartics2Module.forRoot(),
         CommonModule,
         HttpModule,
         // This hack is needed because there is a routerLink in the template
@@ -52,6 +55,7 @@ describe('RepoComponent', () => {
       ],
       providers: [
         AgencyService,
+        Angulartics2,
         ReposService,
         ModalService,
         SeoService,

--- a/src/app/components/home/home.component.spec.ts
+++ b/src/app/components/home/home.component.spec.ts
@@ -1,4 +1,9 @@
+import { APP_BASE_HREF } from '@angular/common';
 import { inject, TestBed } from '@angular/core/testing';
+import { RouterModule } from '@angular/router';
+import { SpyLocation } from '@angular/common/testing';
+
+import { Angulartics2, Angulartics2Module } from 'angulartics2';
 
 import { BannerArtComponent } from './banner-art';
 import { ExternalLinkDirective } from '../../directives/external-link';
@@ -18,7 +23,14 @@ describe('HomeComponent', () => {
         HomeComponent,
         ModalComponent
       ],
+      imports: [
+        Angulartics2Module.forRoot(),
+        RouterModule.forRoot([])
+      ],
       providers: [
+        Angulartics2,
+        {provide: APP_BASE_HREF, useValue: '/'},
+        { provide: Location, useClass: SpyLocation },
         ModalService,
         SeoService,
         StateService

--- a/src/app/components/modal/modal.component.ts
+++ b/src/app/components/modal/modal.component.ts
@@ -1,3 +1,4 @@
+import { Angulartics2 } from 'angulartics2';
 import { Component, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
 
@@ -16,7 +17,10 @@ export class ModalComponent implements OnDestroy {
   visible: boolean;
   modalSub: Subscription;
 
-  constructor(private modalService: ModalService) {
+  constructor(
+    private angulartics2: Angulartics2,
+    private modalService: ModalService
+  ) {
     this.modalSub = modalService.modalActivated$.subscribe(
       modal => {
         this.description = modal['description'];
@@ -32,6 +36,7 @@ export class ModalComponent implements OnDestroy {
   }
 
   close() {
+    this.angulartics2.eventTrack.next({ action: 'Close', properties: { category: 'Modal' }});
     this.visible = false;
   }
 }

--- a/src/app/components/modal/modal.template.html
+++ b/src/app/components/modal/modal.template.html
@@ -11,7 +11,7 @@
     <div class="modal-content">
       <p *ngIf="description">{{ description }}</p>
       <p class="link-pretext">Continue to:</p>
-      <a *ngIf="url" href="{{ url }}" target="_blank" rel="noopener">
+      <a *ngIf="url" angulartics2On="click" angularticsEvent="Link Click" angularticsCategory="Modal" [angularticsProperties]="{ label: url }" href="{{ url }}" target="_blank" rel="noopener">
         {{ url }}
       </a>
     </div>

--- a/src/app/directives/external-link/external-link.directive.spec.ts
+++ b/src/app/directives/external-link/external-link.directive.spec.ts
@@ -1,6 +1,11 @@
 import { Component, Directive } from '@angular/core';
 import { inject, TestBed } from '@angular/core/testing';
+import { Location } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { SpyLocation } from '@angular/common/testing';
+
 import { Observable } from 'rxjs';
+import { Angulartics2 } from 'angulartics2';
 
 import { ExternalLinkDirective } from './external-link.directive';
 import { ModalService } from '../../services/modal';
@@ -10,11 +15,26 @@ describe('ExternalLinkDirective', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [ ExternalLinkDirective, TestComponent ],
-      providers: [{provide: ModalService, useClass: mockModalService}]
+      imports: [ RouterModule.forRoot([]) ],
+      providers: [
+        Angulartics2,
+        { provide: Location, useClass: SpyLocation },
+        { provide: ModalService, useClass: mockModalService }
+      ]
     });
 
     this.fixture = TestBed.createComponent(TestComponent);
     this.fixture.detectChanges();
+  });
+
+  it('should trigger Angularitics when an external link is quicked', () => {
+    let angulartics2 = TestBed.get(Angulartics2);
+    spyOn(angulartics2.eventTrack, "next");
+    this.fixture.debugElement.nativeElement.querySelector('#ext-link').click();
+
+    expect(angulartics2.eventTrack.next).toHaveBeenCalledWith(
+      { action: 'Click', properties: { category: 'External Link' }}
+    );
   });
 
   it('should trigger the ModalService when an external link is quicked', () => {

--- a/src/app/directives/external-link/external-link.directive.ts
+++ b/src/app/directives/external-link/external-link.directive.ts
@@ -1,4 +1,6 @@
+import { Angulartics2 } from 'angulartics2';
 import { Directive, ElementRef, Output, Renderer } from '@angular/core';
+
 import { ModalService } from '../../services/modal';
 
 @Directive({
@@ -12,7 +14,11 @@ export class ExternalLinkDirective {
   modalContent: Object;
   url: string;
 
-  constructor(private el: ElementRef, private modalService: ModalService) {
+  constructor(
+    private angulartics2: Angulartics2,
+    private el: ElementRef,
+    private modalService: ModalService
+  ) {
     this.modalContent = {
       description: 'But you probably knew that already.',
       description2: 'Continue to the link below:',
@@ -27,6 +33,8 @@ export class ExternalLinkDirective {
 
   onClick(event: any) {
     this.url = this.el.nativeElement.getAttribute('href');
+
+    this.angulartics2.eventTrack.next({ action: 'Click', properties: { category: 'External Link' }});
 
     if (this.isExternalLink(this.url)) {
       event.preventDefault();


### PR DESCRIPTION
Adds custom event tracking to ExternalLinkDirective and ModalComponents on certain actions.

* Add close event to ModalComponent Close function
* Add click event to ExternalLinkDirective
* Add link click event via Angulartics2 directive to URL in the ModalComponent template