### PR TITLE
Test Pluralize Pipe and Update Pipe

### DIFF
--- a/src/app/pipes/language-icon/language-icon.pipe.spec.ts
+++ b/src/app/pipes/language-icon/language-icon.pipe.spec.ts
@@ -29,7 +29,6 @@ describe('LanguageIconPipe', () => {
   });
 
   describe('transform', () => {
-
     it('returns code_badge if the argument is not defined in LANGUAGES', () => {
       let value = 'made up language';
 

--- a/src/app/pipes/pluralize/pluralize.pipe.spec.ts
+++ b/src/app/pipes/pluralize/pluralize.pipe.spec.ts
@@ -1,0 +1,40 @@
+import { Component } from '@angular/core';
+
+import * as Pluralize from 'pluralize';
+import { PluralizePipe } from './pluralize.pipe';
+
+/**
+ * Unit tests for IsDefinedPipe including tests for
+ * IsDefinedPipe.transform() and tests where the pipe
+ * is integrated into a template.
+ */
+describe('PluralizePipe', () => {
+  let pipe: PluralizePipe;
+
+  beforeEach(() => {
+      pipe = new PluralizePipe();
+  });
+
+  describe('transform', () => {
+    const pluralize:any = Pluralize;
+    const value = 'Value';
+
+    it('calls Pluralize', () => {
+      expect(pipe.transform(value, 1)).toEqual(pluralize(value, 1));
+    });
+
+    describe('when a number greater than 1 is passed as an argument', () => {
+      const value = 'Value';
+
+      it('returns a plural value', () => {
+        expect(pipe.transform(value, 2)).toEqual('Values');
+      });
+    });
+
+    describe('when a number less than 2 is passed as an argument', () => {
+      it('returns a singular value', () => {
+        expect(pipe.transform(value, 1)).toEqual(value);
+      });
+    });
+  });
+});

--- a/src/app/pipes/pluralize/pluralize.pipe.ts
+++ b/src/app/pipes/pluralize/pluralize.pipe.ts
@@ -9,6 +9,6 @@ export class PluralizePipe implements PipeTransform {
   transform(value: string, arg: number): any {
     const pluralize:any = Pluralize;
 
-    return pluralize.plural(value, arg);
+    return pluralize(value, arg);
   }
 }


### PR DESCRIPTION
Fixes an issue with the Pluralize pipe forcing pluralization and adds test for the PluralizePipe.

* Add tests for the PluralizePipe
* Use pluralize(v,a) syntax to prevent forced pluralization via the pluralize.plural(v,a) function