### PR TITLE
Connect Repo Page to API

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "tslint": "~3.15.1",
     "tslint-loader": "^2.1.5",
     "typedoc": "^0.5.0",
-    "typescript": "^2.0.3",
+    "typescript": "2.1.1",
     "url-loader": "^0.5.7",
     "uswds": "^0.12.1",
     "webpack": "2.1.0-beta.25",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -28,6 +28,7 @@ import { APP_COMPONENTS } from './utils/app-components';
 import { AgencyService, AGENCIES } from './services/agency';
 import { MobileService } from './services/mobile';
 import { ModalService } from './services/modal';
+import { RepoService } from './services/repo';
 import { ReposService } from './services/repos';
 import { SearchService } from './services/search';
 import { SeoService } from './services/seo';
@@ -39,6 +40,7 @@ const APP_PROVIDERS = [
   AgencyService,
   MobileService,
   ModalService,
+  RepoService,
   ReposService,
   SearchService,
   SeoService,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -13,5 +13,6 @@ export const ROUTES: Routes = [
   ...EXPLORE_CODE_ROUTES,
   ...POLICY_GUIDE_ROUTES,
   { path: 'privacy-policy', component: PrivacyPolicyComponent },
+  { path: '404', component: FourOhFourComponent },
   { path: '**', component: FourOhFourComponent }
 ];

--- a/src/app/components/explore-code/repo/repo.component.ts
+++ b/src/app/components/explore-code/repo/repo.component.ts
@@ -1,9 +1,9 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs/Subscription';
 import { AgencyService, Agency } from '../../../services/agency';
 import { ExternalLinkDirective } from '../../../directives/external-link';
-import { ReposService } from '../../../services/repos';
+import { RepoService } from '../../../services/repo';
 import { SeoService } from '../../../services/seo';
 
 @Component({
@@ -13,17 +13,21 @@ import { SeoService } from '../../../services/seo';
 })
 
 export class RepoComponent implements OnInit, OnDestroy {
-  agency: Agency;
   repo: any;
   eventSub: Subscription;
   repoSub: Subscription;
 
   constructor(
     private route: ActivatedRoute,
+    private router: Router,
     private agencyService: AgencyService,
-    private reposService: ReposService,
+    private repoService: RepoService,
     private seoService: SeoService
   ) {}
+
+  navigateTo404() {
+    this.router.navigateByUrl('404');
+  }
 
   ngOnInit() {
     this.eventSub = this.route.params.subscribe(params => {
@@ -40,17 +44,20 @@ export class RepoComponent implements OnInit, OnDestroy {
   }
 
   getRepo(id) {
-    this.repoSub = this.reposService.getJsonFile().
-      subscribe((result) => {
+    this.repoSub = this.repoService.getRepo(id).subscribe(
+      result => {
         if (result) {
-          this.repo = result['repos'].filter(repo => repo.repoID === id)[0];
-          this.repo.agency = this.agencyService.getAgency(this.repo.agency);
+          this.repo = result;
           this.seoService.setTitle(this.repo.name, true);
           this.seoService.setMetaDescription(this.repo.description);
           this.seoService.setMetaRobots('Index, Follow');
         } else {
-          console.log('Error. Source code repositories not found');
+          this.navigateTo404();
         }
-    });
+      },
+      error => {
+        this.navigateTo404();
+      }
+    );
   }
 }

--- a/src/app/components/explore-code/repo/repo.template.html
+++ b/src/app/components/explore-code/repo/repo.template.html
@@ -2,8 +2,8 @@
   <header>
     <div class="repo-header-container">
       <h3>
-        <a routerLink="/explore-code/agencies/{{repo.agency.id}}">
-          {{ repo.agency.name }}
+        <a routerLink="/explore-code/agencies/{{repo.agency}}">
+          {{ repo.agency }}
         </a>
       </h3>
       <h1>{{ repo.name }}</h1>
@@ -17,8 +17,8 @@
           </a>
         </li>
 
-        <li *ngIf="repo.repoURL | isdefined">
-          <a external-link class="usa-button" href="{{ repo.repoURL }}">
+        <li *ngIf="repo.repository | isdefined">
+          <a external-link class="usa-button" href="{{ repo.repository }}">
             Visit Repo
           </a>
         </li>

--- a/src/app/components/explore-code/search-results/search-results.template.html
+++ b/src/app/components/explore-code/search-results/search-results.template.html
@@ -5,7 +5,7 @@
   </p>
   <ul class="repos-list usa-unstyled-list">
     <li *ngFor="let repo of repos" class="repo">
-      <a>
+      <a routerLink="/explore-code/repos/{{repo.repoID}}">
         <h3 class="repo-name">{{ repo.name }}</h3>
         <p class="repo-description">
           {{ repo.description | truncate : 200 }}

--- a/src/app/components/repos-search/repos-search.component.spec.ts
+++ b/src/app/components/repos-search/repos-search.component.spec.ts
@@ -1,32 +1,53 @@
 import { APP_BASE_HREF } from '@angular/common';
+import { Component } from '@angular/core';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { async, ComponentFixture, inject, TestBed } from '@angular/core/testing';
 import { HttpModule } from '@angular/http';
-import { RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Router } from '@angular/router';
+
+import { Observable } from 'rxjs/Rx';
 
 import { ReposSearchComponent } from './';
 import { SearchService } from '../../services/search';
 
 describe('ReposSearchComponent', () => {
 
+  let mockRouter:any;
+
+
   beforeEach(() => {
+    mockRouter = new MockRouter();
+
     TestBed.configureTestingModule({
       declarations: [
+        FakeComponent,
         ReposSearchComponent
       ],
       imports: [
         HttpModule,
-        ReactiveFormsModule,
-        RouterModule.forRoot([])
+        ReactiveFormsModule
       ],
       providers: [
-        {provide: APP_BASE_HREF, useValue: '/'},
-        SearchService,
+        { provide: APP_BASE_HREF, useValue: '/' },
+        { provide: SearchService, useClass: MockSearchService },
+        { provide: Router, useClass: MockRouter }
       ]
     });
 
     this.fixture = TestBed.createComponent(ReposSearchComponent);
     this.reposSearchComponent = this.fixture.componentInstance;
+  });
+
+  describe('navigateToResults', () => {
+    it('should navigate to results page if not there already',
+      inject([Router], router => {
+      spyOn(router, 'navigateByUrl');
+
+      this.reposSearchComponent.navigateToResults();
+
+      expect(router.navigateByUrl).toHaveBeenCalled();
+    }));
   });
 
   describe('onSubmit', () => {
@@ -38,4 +59,59 @@ describe('ReposSearchComponent', () => {
       expect(this.reposSearchComponent.search).toHaveBeenCalledWith('GSA');
     });
   });
+
+  describe('search', () => {
+    it('should call the search service',
+      inject([SearchService], searchService => {
+      spyOn(searchService, 'setSearchResults');
+      spyOn(this.reposSearchComponent, 'navigateToResults');
+
+      spyOn(searchService, 'search').and.callFake(function(start, size, query) {
+        return Observable.of({ response: 'success'});
+      });
+
+      this.reposSearchComponent.search('GSA');
+      expect(searchService.search).toHaveBeenCalledWith(0, 10, 'GSA');
+    }));
+
+    it('should call the navigateToResults function',
+      inject([SearchService], searchService => {
+      spyOn(searchService, 'setSearchResults');
+      spyOn(this.reposSearchComponent, 'navigateToResults');
+
+      spyOn(searchService, 'search').and.callFake(function(start, size, query) {
+        return Observable.of({ response: 'success'});
+      });
+
+      this.reposSearchComponent.search('GSA');
+      expect(this.reposSearchComponent.navigateToResults).toHaveBeenCalledWith();
+    }));
+  });
 });
+
+@Component({
+  template: ''
+})
+class FakeComponent {}
+
+class MockRouter {
+  url: string;
+  constructor() {
+    this.url = '/explore-code/';
+  }
+
+  navigateByUrl() {
+    return true;
+  }
+}
+
+class MockSearchService {
+  result = [{repos: [{name: 'GSA'}, {name: 'GSA 2'}, {name: 'GSA 3'}]}];
+  search(arg, arg2, arg3) {
+    return Observable.of(this.result);
+  }
+
+  setSearchResults(result) {
+    return true;
+  }
+}

--- a/src/app/components/repos-search/repos-search.component.ts
+++ b/src/app/components/repos-search/repos-search.component.ts
@@ -37,16 +37,22 @@ export class ReposSearchComponent {
   }
 
   onSubmit(form: any): void {
-    console.log(form);
     this.search(form.query);
   }
 
   search(query: string) {
-    this.searchService.search(0, 10, query).subscribe((result) => {
-      if (result) {
-        this.searchService.setSearchResults(result['repos']);
-        this.navigateToResults();
+    this.searchService.search(0, 10, query).subscribe(
+      result => {
+        if (result) {
+           this.searchService.setSearchResults(result['repos']);
+           this.navigateToResults();
+        } else {
+          console.log("No Repos Found");
+        }
+      },
+      error => {
+        console.log(error)
       }
-    });
+    );
   }
 }

--- a/src/app/services/repo/index.ts
+++ b/src/app/services/repo/index.ts
@@ -1,0 +1,1 @@
+export * from './repo.service';

--- a/src/app/services/repo/repo.service.ts
+++ b/src/app/services/repo/repo.service.ts
@@ -1,0 +1,19 @@
+import { Http, Response } from '@angular/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Rx';
+import { Subject } from 'rxjs/Subject';
+import 'rxjs/add/operator/map';
+
+@Injectable()
+
+export class RepoService {
+  private repo: Object;
+
+  constructor(private http: Http) {}
+
+  getRepo(id: string): Observable<Response> {
+    let repoUrl = API_URL + 'repo/' + id;
+
+    return this.http.get(repoUrl).map((res:Response) => res.json());
+  }
+}


### PR DESCRIPTION
Creates a RepoService for handling interactions between the RepoComponent and the Code.gov API.

* Create RepoService to fetch a given Repo from the API
* Modify RepoComponent to use RepoService to fetch RepoData
* Redirect /repos/:id to 404 page if Repo does not exist
* Create explicit 404 route
* Add tests for the RepoSearchComponent