### PR TITLE
Add Infinite Scroll to Search Results

### DIFF
--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -24,8 +24,7 @@ module.exports = function(config) {
     files: [ { pattern: './config/spec-bundle.js', watched: false } ],
 
     proxies: {
-        '/assets/fonts/': '/base/assets/fonts/',
-        "/app/": '/base/build/app/'
+        '/assets/fonts/': '/base/assets/fonts/'
     },
 
     /*

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@angularclass/conventions-loader": "^1.0.2",
     "@angularclass/hmr": "~1.2.0",
     "@angularclass/hmr-loader": "~3.0.2",
+    "angular2-infinite-scroll": "^0.2.8",
     "angulartics2": "1.4.3",
     "assets-webpack-plugin": "^3.4.0",
     "bourbon": "^4.2.7",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -4,11 +4,11 @@ import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
 import { RouterModule } from '@angular/router';
 import { removeNgStyles, createNewHosts } from '@angularclass/hmr';
-import { AuthHttp, AuthConfig, AUTH_PROVIDERS, provideAuth} from 'angular2-jwt';
 import { HashLocationStrategy, LocationStrategy } from '@angular/common';
 
 import { Angulartics2On } from 'angulartics2';
 import { Angulartics2Module, Angulartics2GoogleTagManager } from 'angulartics2';
+import { InfiniteScrollModule } from 'angular2-infinite-scroll';
 
 /*
  * Platform and Environment providers/directives/pipes
@@ -55,8 +55,9 @@ const APP_PROVIDERS = [
     Angulartics2Module.forRoot(),
     BrowserModule,
     FormsModule,
-    ReactiveFormsModule,
     HttpModule,
+    InfiniteScrollModule,
+    ReactiveFormsModule,
     RouterModule.forRoot(ROUTES, { useHash: true })
   ],
   declarations: [

--- a/src/app/components/explore-code/search-results/search-results.component.spec.ts
+++ b/src/app/components/explore-code/search-results/search-results.component.spec.ts
@@ -1,0 +1,256 @@
+import { APP_BASE_HREF } from '@angular/common';
+import { Component } from '@angular/core';
+import { ComponentFixture, inject, TestBed } from '@angular/core/testing';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { HttpModule } from '@angular/http';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { InfiniteScrollModule } from 'angular2-infinite-scroll';
+import { Observable } from 'rxjs/Rx';
+
+import { LanguageIconPipe } from '../../../pipes/language-icon';
+import { PluralizePipe } from '../../../pipes/pluralize';
+import { ReposSearchComponent } from '../../repos-search';
+import { SearchResultsComponent } from './';
+import { SearchService } from '../../../services/search';
+import { TruncatePipe } from '../../../pipes/truncate';
+
+describe('SearchResultsComponent', () => {
+
+  describe('getMoreRepos', () => {
+
+    describe(
+      'when the repo count is greater than or equal to the number of' +
+      'Displayed Repos ', () => {
+        beforeEach(() => {
+          TestBed.configureTestingModule({
+            declarations: [
+              LanguageIconPipe,
+              PluralizePipe,
+              ReposSearchComponent,
+              SearchResultsComponent,
+              TruncatePipe
+            ],
+            imports: [
+              HttpModule,
+              InfiniteScrollModule,
+              ReactiveFormsModule,
+              RouterModule
+            ],
+            providers: [
+              { provide: SearchService, useClass: MockSearchService },
+              { provide: Router, useClass: MockRouter }
+            ]
+          });
+
+          let service = TestBed.get(SearchService, null);
+
+          spyOn(service, 'getDisplayedRepos').and.returnValue(5);
+          spyOn(service, 'getReposCount').and.returnValue(5);
+
+          this.fixture = TestBed.createComponent(SearchResultsComponent);
+          this.searchResultsComponent = this.fixture.componentInstance;
+        });
+
+        it('does nothing', inject([SearchService], searchService => {
+          spyOn(searchService, 'search');
+
+          this.searchResultsComponent.getMoreRepos();
+
+          expect(searchService.search).not.toHaveBeenCalled();
+        }));
+      }
+    );
+
+    describe(
+      'when the number of Displayed Repos is less than the total number ' +
+      'of Repos', () => {
+        beforeEach(() => {
+          TestBed.configureTestingModule({
+            declarations: [
+              LanguageIconPipe,
+              PluralizePipe,
+              ReposSearchComponent,
+              SearchResultsComponent,
+              TruncatePipe
+            ],
+            imports: [
+              HttpModule,
+              InfiniteScrollModule,
+              ReactiveFormsModule,
+              RouterTestingModule
+            ],
+            providers: [
+              { provide: SearchService, useClass: MockSearchService },
+              { provide: Router, useClass: MockRouter }
+            ]
+          });
+
+          let service = TestBed.get(SearchService, null);
+
+          spyOn(service, 'getDisplayedRepos').and.returnValue(4);
+          spyOn(service, 'getReposCount').and.returnValue(5);
+
+          this.fixture = TestBed.createComponent(SearchResultsComponent);
+          this.searchResultsComponent = this.fixture.componentInstance;
+        });
+
+        it('calls the Search Service search function',
+          inject([SearchService], searchService => {
+            spyOn(searchService, 'getSearchStart').and.returnValue(4);
+            spyOn(searchService, 'getQuery').and.returnValue('GSA');
+            spyOn(searchService, 'search').and.callThrough();
+
+            this.searchResultsComponent.getMoreRepos();
+
+            expect(searchService.search).toHaveBeenCalledWith(
+              searchService.getSearchStart(),
+              10,
+              searchService.getQuery()
+            );
+          }
+        ));
+      }
+    );
+  });
+
+  describe('ngOnInit', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        declarations: [
+          LanguageIconPipe,
+          PluralizePipe,
+          ReposSearchComponent,
+          SearchResultsComponent,
+          TruncatePipe
+        ],
+        imports: [
+          HttpModule,
+          InfiniteScrollModule,
+          ReactiveFormsModule,
+          RouterTestingModule.withRoutes([
+           {
+             path: 'explore-code/repos/:id',
+             component: SearchResultsComponent
+           }
+          ])
+        ],
+        providers: [
+          { provide: SearchService, useClass: MockSearchService }
+        ]
+      });
+    });
+
+    it('subscribes to the searchResults from the SearchService',
+      inject([SearchService], searchService => {
+        spyOn(searchService, 'searchResults').and.callFake(function() {
+          return Observable.of([{repoId: 1}, {repoId: 2}])
+        });
+
+        let fixture = TestBed.createComponent(SearchResultsComponent);
+        fixture.detectChanges();
+
+        expect(searchService.searchResults).toHaveBeenCalled();
+      })
+    );
+  });
+
+  describe('onScroll', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        declarations: [
+          LanguageIconPipe,
+          PluralizePipe,
+          ReposSearchComponent,
+          SearchResultsComponent,
+          TruncatePipe
+        ],
+        imports: [
+          HttpModule,
+          InfiniteScrollModule,
+          ReactiveFormsModule,
+          RouterTestingModule
+        ],
+        providers: [
+          { provide: SearchService, useClass: MockSearchService }
+        ]
+      });
+
+      this.fixture = TestBed.createComponent(SearchResultsComponent);
+      this.searchResultsComponent = this.fixture.componentInstance;
+    });
+
+    it('calls the getMoreRepos function', () => {
+      spyOn(this.searchResultsComponent, 'getMoreRepos');
+
+      this.searchResultsComponent.onScroll();
+
+      expect(this.searchResultsComponent.getMoreRepos).toHaveBeenCalled();
+    });
+  });
+});
+
+class MockRouter {
+  url: string;
+  constructor() {
+    this.url = '/explore-code/';
+  }
+
+  navigateByUrl() {
+    return true;
+  }
+}
+
+class MockSearchService {
+  result = {total: 3, repos: [{name: 'GSA'}, {name: 'GSA 2'}, {name: 'GSA 3'}]};
+  repos: any = this.result['repos'];
+
+  addDisplayedRepos(value) {
+    return true;
+  }
+
+  addSearchStart(value) {
+    return true;
+  }
+
+  checkRepos() {
+    if (this.getRepos() != null && this.getRepos().length > 0) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  getDisplayedRepos() {
+    return 2;
+  }
+
+  getRepos() {
+    return this.repos;
+  }
+
+  getReposCount() {
+    return this.result['total'];
+  }
+
+  getSearchStart() {
+    return 2;
+  }
+
+  getQuery() {
+    return 'GSA';
+  }
+
+  search(arg, arg2, arg3) {
+    return Observable.of(this.result);
+  }
+
+  searchResults() {
+    return Observable.of(this.repos);
+  }
+
+  setSearchResults(result) {
+    return true;
+  }
+}

--- a/src/app/components/explore-code/search-results/search-results.component.ts
+++ b/src/app/components/explore-code/search-results/search-results.component.ts
@@ -5,24 +5,60 @@ import { SearchService } from '../../../services/search';
 
 @Component({
   selector: 'search-results',
-  templateUrl: './search-results.template.html'
+  template: require('./search-results.template.html')
 })
 
 export class SearchResultsComponent {
+  public hasRepos: boolean;
   public repos: any;
+  private displayedRepos: number;
+  private query: string;
+  private reposCount: number;
+  private searchStart: number = 0;
   private reposSub: Subscription;
 
   constructor(private searchService: SearchService){
+    this.hasRepos = searchService.checkRepos();
+
     this.repos = searchService.getRepos();
+    this.reposCount = searchService.getReposCount();
+    this.displayedRepos = searchService.getDisplayedRepos();
+    this.searchStart = searchService.getSearchStart();
   }
 
-  hasRepos() {
-    this.searchService.hasRepos;
+  getMoreRepos() {
+    if (this.displayedRepos < this.reposCount) {
+      this.searchService.search(
+        this.searchService.getSearchStart(),
+        10,
+        this.searchService.getQuery()).subscribe(
+        result => {
+          if (result) {
+            this.searchService.addDisplayedRepos(result['repos'].length);
+            this.searchService.addSearchStart(result['repos'].length);
+            this.repos.push(...result['repos']);
+          } else {
+            console.log("No Repos Found");
+          }
+        },
+        error => {
+          console.log(error)
+        }
+      );
+    }
   }
 
   ngOnInit() {
-    this.reposSub = this.searchService.searchResults$.subscribe((result) => {
+    this.reposSub = this.searchService.searchResults().subscribe((result) => {
+      this.displayedRepos = this.searchService.getDisplayedRepos();
+      this.searchStart = this.searchService.getSearchStart();
+      this.reposCount = this.searchService.getReposCount();
       this.repos = result;
+      this.hasRepos = this.searchService.checkRepos();
     });
+  }
+
+  onScroll() {
+    this.getMoreRepos();
   }
 }

--- a/src/app/components/explore-code/search-results/search-results.template.html
+++ b/src/app/components/explore-code/search-results/search-results.template.html
@@ -3,7 +3,11 @@
   <p class="repos-count">
     {{ repos.length }} Featured {{ "Projects" | pluralize : repos.length }}
   </p>
-  <ul class="repos-list usa-unstyled-list">
+  <ul class="repos-list usa-unstyled-list"
+    infinite-scroll
+    [infiniteScrollDistance]="2"
+    [infiniteScrollThrottle]="500"
+    (scrolled)="onScroll()">
     <li *ngFor="let repo of repos" class="repo">
       <a routerLink="/explore-code/repos/{{repo.repoID}}">
         <h3 class="repo-name">{{ repo.name }}</h3>

--- a/src/app/components/repos-search/repos-search.component.spec.ts
+++ b/src/app/components/repos-search/repos-search.component.spec.ts
@@ -21,7 +21,6 @@ describe('ReposSearchComponent', () => {
 
     TestBed.configureTestingModule({
       declarations: [
-        FakeComponent,
         ReposSearchComponent
       ],
       imports: [
@@ -79,20 +78,24 @@ describe('ReposSearchComponent', () => {
       spyOn(searchService, 'setSearchResults');
       spyOn(this.reposSearchComponent, 'navigateToResults');
 
-      spyOn(searchService, 'search').and.callFake(function(start, size, query) {
-        return Observable.of({ response: 'success'});
-      });
+      spyOn(searchService, 'search').and.callThrough();
 
       this.reposSearchComponent.search('GSA');
-      expect(this.reposSearchComponent.navigateToResults).toHaveBeenCalledWith();
+      expect(this.reposSearchComponent.navigateToResults).toHaveBeenCalled();
+    }));
+
+    it('should call the setSearchResults function in the SearchService',
+      inject([SearchService], searchService => {
+      spyOn(searchService, 'setSearchResults');
+      spyOn(this.reposSearchComponent, 'navigateToResults');
+
+      spyOn(searchService, 'search').and.callThrough();
+
+      this.reposSearchComponent.search('GSA');
+      expect(searchService.setSearchResults).toHaveBeenCalledWith(searchService.getResult(), 3);
     }));
   });
 });
-
-@Component({
-  template: ''
-})
-class FakeComponent {}
 
 class MockRouter {
   url: string;
@@ -106,7 +109,12 @@ class MockRouter {
 }
 
 class MockSearchService {
-  result = [{repos: [{name: 'GSA'}, {name: 'GSA 2'}, {name: 'GSA 3'}]}];
+  result = {total: 3, repos: [{name: 'GSA'}, {name: 'GSA 2'}, {name: 'GSA 3'}]};
+
+  getResult() {
+    return this.result['repos'];
+  }
+
   search(arg, arg2, arg3) {
     return Observable.of(this.result);
   }

--- a/src/app/components/repos-search/repos-search.component.ts
+++ b/src/app/components/repos-search/repos-search.component.ts
@@ -44,8 +44,8 @@ export class ReposSearchComponent {
     this.searchService.search(0, 10, query).subscribe(
       result => {
         if (result) {
-           this.searchService.setSearchResults(result['repos']);
-           this.navigateToResults();
+          this.searchService.setSearchResults(result['repos'], result['total']);
+          this.navigateToResults();
         } else {
           console.log("No Repos Found");
         }

--- a/src/app/services/search/search.service.ts
+++ b/src/app/services/search/search.service.ts
@@ -7,12 +7,24 @@ import 'rxjs/add/operator/map';
 @Injectable()
 
 export class SearchService {
-  public hasRepos: boolean;
+  public hasRepos: boolean = false;
+  public query: string;
+  private displayedRepos: number;
   private repos: Array<any>;
+  private reposCount: number;
   private results = new Subject<boolean>();
-  searchResults$ = this.results.asObservable();
+  private searchStart: number;
 
   constructor(private http: Http) {}
+
+  addDisplayedRepos(count) {
+    this.displayedRepos += count;
+  }
+
+  addSearchStart(newStart) {
+    this.searchStart += newStart;
+  }
+
 
   checkRepos() {
     if (this.getRepos() != null && this.getRepos().length > 0) {
@@ -22,20 +34,47 @@ export class SearchService {
     }
   }
 
+  getDisplayedRepos() {
+    return this.displayedRepos;
+  }
+
+  getSearchStart() {
+    return this.searchStart;
+  }
+
   getRepos() {
     return this.repos;
   }
 
+  getReposCount() {
+    return this.reposCount;
+  }
+
+  getQuery() {
+    return this.query;
+  }
+
   search(from: number, size: number, query: string): Observable<Response> {
+    this.query = query;
+
     let queryParams = '?_fulltext=' + query + '&from=' + from + '&size=' + size;
     let queryUrl = API_URL + 'repos' + queryParams;
 
-    return this.http.get(queryUrl).map((res:Response) => res.json());
+    return this.http.get(queryUrl).map(
+      (res:Response) => res.json());
   }
 
-  setSearchResults(result) {
-    this.hasRepos = this.checkRepos();
+  searchResults(): Observable<any> {
+    return this.results;
+  }
+
+  setSearchResults(result, total) {
     this.repos = result;
+    this.displayedRepos = result.length;
+    this.hasRepos = this.checkRepos();
+    this.reposCount = total;
+    this.searchStart = result.length;
+
     this.results.next(result);
   }
 }


### PR DESCRIPTION
Loads additional results as Users scroll through the SearchResults page.

* Add angular2-infinite-scroll package for handling infinite scroll
* Add infinite-scroll Directive to SearchResultsComponent Template
* Modify SearchService to store Results
* Add variables to SearchResultsComponent to update based on SearchService changes