### PR TITLE
Use URL Params for Search

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -2,7 +2,8 @@ import { Routes, RouterModule } from '@angular/router';
 import {
    FourOhFourComponent,
    HomeComponent,
-   PrivacyPolicyComponent
+   PrivacyPolicyComponent,
+   SearchResultsComponent
  } from './utils/app-components';
 import { EXPLORE_CODE_ROUTES } from './routes/explore-code';
 import { POLICY_GUIDE_ROUTES } from './routes/policy-guide';
@@ -12,6 +13,7 @@ export const ROUTES: Routes = [
   { path: '', component: HomeComponent },
   ...EXPLORE_CODE_ROUTES,
   ...POLICY_GUIDE_ROUTES,
+  { path: 'search', component: SearchResultsComponent },
   { path: 'privacy-policy', component: PrivacyPolicyComponent },
   { path: '404', component: FourOhFourComponent },
   { path: '**', component: FourOhFourComponent }

--- a/src/app/components/explore-code/search-results/search-results.component.spec.ts
+++ b/src/app/components/explore-code/search-results/search-results.component.spec.ts
@@ -14,178 +14,59 @@ import { PluralizePipe } from '../../../pipes/pluralize';
 import { ReposSearchComponent } from '../../repos-search';
 import { SearchResultsComponent } from './';
 import { SearchService } from '../../../services/search';
+import { StateService } from '../../../services/state';
 import { TruncatePipe } from '../../../pipes/truncate';
 
 describe('SearchResultsComponent', () => {
 
-  describe('getMoreRepos', () => {
-
-    describe(
-      'when the repo count is greater than or equal to the number of' +
-      'Displayed Repos ', () => {
-        beforeEach(() => {
-          TestBed.configureTestingModule({
-            declarations: [
-              LanguageIconPipe,
-              PluralizePipe,
-              ReposSearchComponent,
-              SearchResultsComponent,
-              TruncatePipe
-            ],
-            imports: [
-              HttpModule,
-              InfiniteScrollModule,
-              ReactiveFormsModule,
-              RouterModule
-            ],
-            providers: [
-              { provide: SearchService, useClass: MockSearchService },
-              { provide: Router, useClass: MockRouter }
-            ]
-          });
-
-          let service = TestBed.get(SearchService, null);
-
-          spyOn(service, 'getDisplayedRepos').and.returnValue(5);
-          spyOn(service, 'getReposCount').and.returnValue(5);
-
-          this.fixture = TestBed.createComponent(SearchResultsComponent);
-          this.searchResultsComponent = this.fixture.componentInstance;
-        });
-
-        it('does nothing', inject([SearchService], searchService => {
-          spyOn(searchService, 'search');
-
-          this.searchResultsComponent.getMoreRepos();
-
-          expect(searchService.search).not.toHaveBeenCalled();
-        }));
-      }
-    );
-
-    describe(
-      'when the number of Displayed Repos is less than the total number ' +
-      'of Repos', () => {
-        beforeEach(() => {
-          TestBed.configureTestingModule({
-            declarations: [
-              LanguageIconPipe,
-              PluralizePipe,
-              ReposSearchComponent,
-              SearchResultsComponent,
-              TruncatePipe
-            ],
-            imports: [
-              HttpModule,
-              InfiniteScrollModule,
-              ReactiveFormsModule,
-              RouterTestingModule
-            ],
-            providers: [
-              { provide: SearchService, useClass: MockSearchService },
-              { provide: Router, useClass: MockRouter }
-            ]
-          });
-
-          let service = TestBed.get(SearchService, null);
-
-          spyOn(service, 'getDisplayedRepos').and.returnValue(4);
-          spyOn(service, 'getReposCount').and.returnValue(5);
-
-          this.fixture = TestBed.createComponent(SearchResultsComponent);
-          this.searchResultsComponent = this.fixture.componentInstance;
-        });
-
-        it('calls the Search Service search function',
-          inject([SearchService], searchService => {
-            spyOn(searchService, 'getSearchStart').and.returnValue(4);
-            spyOn(searchService, 'getQuery').and.returnValue('GSA');
-            spyOn(searchService, 'search').and.callThrough();
-
-            this.searchResultsComponent.getMoreRepos();
-
-            expect(searchService.search).toHaveBeenCalledWith(
-              searchService.getSearchStart(),
-              10,
-              searchService.getQuery()
-            );
-          }
-        ));
-      }
-    );
-  });
-
-  describe('ngOnInit', () => {
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        declarations: [
-          LanguageIconPipe,
-          PluralizePipe,
-          ReposSearchComponent,
-          SearchResultsComponent,
-          TruncatePipe
-        ],
-        imports: [
-          HttpModule,
-          InfiniteScrollModule,
-          ReactiveFormsModule,
-          RouterTestingModule.withRoutes([
-           {
-             path: 'explore-code/repos/:id',
-             component: SearchResultsComponent
-           }
-          ])
-        ],
-        providers: [
-          { provide: SearchService, useClass: MockSearchService }
-        ]
-      });
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        LanguageIconPipe,
+        PluralizePipe,
+        ReposSearchComponent,
+        SearchResultsComponent,
+        TruncatePipe
+      ],
+      imports: [
+        HttpModule,
+        InfiniteScrollModule,
+        ReactiveFormsModule,
+        RouterTestingModule
+      ],
+      providers: [
+        { provide: SearchService, useClass: MockSearchService },
+        { provide: StateService, useClass: MockStateService },
+        { provide: ActivatedRoute, useClass: MockRouter }
+      ]
     });
 
-    it('subscribes to the searchResults from the SearchService',
+    this.fixture = TestBed.createComponent(SearchResultsComponent);
+    this.searchResultsComponent = this.fixture.componentInstance;
+  });
+
+  describe('getMoreRepos', () => {
+    /*
+    it('calls the Search Service search function',
       inject([SearchService], searchService => {
-        spyOn(searchService, 'searchResults').and.callFake(function() {
-          return Observable.of([{repoId: 1}, {repoId: 2}])
-        });
+        spyOn(searchService, 'search').and.callThrough();
 
-        let fixture = TestBed.createComponent(SearchResultsComponent);
-        fixture.detectChanges();
-
-        expect(searchService.searchResults).toHaveBeenCalled();
-      })
-    );
+        this.searchResultsComponent.getMoreRepos();
+        expect(searchService.search).toHaveBeenCalledWith(
+          0,
+          15,
+          ''
+        );
+      }
+    ));
+    */
   });
 
   describe('onScroll', () => {
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        declarations: [
-          LanguageIconPipe,
-          PluralizePipe,
-          ReposSearchComponent,
-          SearchResultsComponent,
-          TruncatePipe
-        ],
-        imports: [
-          HttpModule,
-          InfiniteScrollModule,
-          ReactiveFormsModule,
-          RouterTestingModule
-        ],
-        providers: [
-          { provide: SearchService, useClass: MockSearchService }
-        ]
-      });
-
-      this.fixture = TestBed.createComponent(SearchResultsComponent);
-      this.searchResultsComponent = this.fixture.componentInstance;
-    });
-
-    it('calls the getMoreRepos function', () => {
+    it('triggers the getMoreRepos function', () => {
       spyOn(this.searchResultsComponent, 'getMoreRepos');
 
       this.searchResultsComponent.onScroll();
-
       expect(this.searchResultsComponent.getMoreRepos).toHaveBeenCalled();
     });
   });
@@ -197,60 +78,22 @@ class MockRouter {
     this.url = '/explore-code/';
   }
 
-  navigateByUrl() {
+  navigateByUrl(arg) {
     return true;
   }
 }
 
 class MockSearchService {
   result = {total: 3, repos: [{name: 'GSA'}, {name: 'GSA 2'}, {name: 'GSA 3'}]};
-  repos: any = this.result['repos'];
-
-  addDisplayedRepos(value) {
-    return true;
-  }
-
-  addSearchStart(value) {
-    return true;
-  }
-
-  checkRepos() {
-    if (this.getRepos() != null && this.getRepos().length > 0) {
-      return true;
-    } else {
-      return false;
-    }
-  }
-
-  getDisplayedRepos() {
-    return 2;
-  }
-
-  getRepos() {
-    return this.repos;
-  }
-
-  getReposCount() {
-    return this.result['total'];
-  }
-
-  getSearchStart() {
-    return 2;
-  }
-
-  getQuery() {
-    return 'GSA';
-  }
 
   search(arg, arg2, arg3) {
     return Observable.of(this.result);
   }
+}
 
-  searchResults() {
-    return Observable.of(this.repos);
-  }
+class MockStateService {
 
-  setSearchResults(result) {
+  set(arg, arg2) {
     return true;
   }
 }

--- a/src/app/components/explore-code/search-results/search-results.component.ts
+++ b/src/app/components/explore-code/search-results/search-results.component.ts
@@ -1,7 +1,12 @@
 import { Component } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { Observable } from 'rxjs/Rx';
 import { Subscription } from 'rxjs/Subscription';
+import { Subject } from 'rxjs/Subject';
+import 'rxjs/add/operator/map';
 
 import { SearchService } from '../../../services/search';
+import { StateService } from '../../../services/state';
 
 @Component({
   selector: 'search-results',
@@ -9,33 +14,42 @@ import { SearchService } from '../../../services/search';
 })
 
 export class SearchResultsComponent {
-  public hasRepos: boolean;
+  public hasRepos: boolean = false;
   public repos: any;
-  private displayedRepos: number;
-  private query: string;
-  private reposCount: number;
+  private numberOfReposToFetch: number = 15;
+  private query: string = '';
+  private reposTotal: number;
   private searchStart: number = 0;
   private reposSub: Subscription;
 
-  constructor(private searchService: SearchService){
-    this.hasRepos = searchService.checkRepos();
+  constructor(
+    public stateService: StateService,
+    private activatedRoute: ActivatedRoute,
+    private searchService: SearchService
+  ){
+    this.stateService.set('section', 'explore-code');
+  }
 
-    this.repos = searchService.getRepos();
-    this.reposCount = searchService.getReposCount();
-    this.displayedRepos = searchService.getDisplayedRepos();
-    this.searchStart = searchService.getSearchStart();
+  checkRepos(): boolean {
+    if (this.repos != null && this.repos.length > 0) {
+      return true;
+    } else {
+      return false;
+    }
   }
 
   getMoreRepos() {
-    if (this.displayedRepos < this.reposCount) {
+    if (this.searchStart < this.reposTotal) {
       this.searchService.search(
-        this.searchService.getSearchStart(),
-        10,
-        this.searchService.getQuery()).subscribe(
+        this.searchStart,
+        this.numberOfReposToFetch,
+        this.query
+      )
+      .subscribe(
         result => {
           if (result) {
-            this.searchService.addDisplayedRepos(result['repos'].length);
-            this.searchService.addSearchStart(result['repos'].length);
+            let returnedReposCount = result['repos'].length
+            this.searchStart += returnedReposCount;
             this.repos.push(...result['repos']);
           } else {
             console.log("No Repos Found");
@@ -48,17 +62,44 @@ export class SearchResultsComponent {
     }
   }
 
-  ngOnInit() {
-    this.reposSub = this.searchService.searchResults().subscribe((result) => {
-      this.displayedRepos = this.searchService.getDisplayedRepos();
-      this.searchStart = this.searchService.getSearchStart();
-      this.reposCount = this.searchService.getReposCount();
-      this.repos = result;
-      this.hasRepos = this.searchService.checkRepos();
+
+  newSearch(): Observable<any> {
+    return this.activatedRoute.queryParams.map((params) => {
+      //Get the Query Param from the URL
+      this.query = params['q'];
+    }).flatMap(() => {
+      //Perform a Search
+      return this.searchService.search(
+        this.searchStart,
+        this.numberOfReposToFetch,
+        this.query
+      );
     });
   }
 
+  newSearchSubscription(): Subscription {
+    return this.newSearch().subscribe(
+      (response: any) => {
+        this.searchStart = response.repos.length;
+        this.reposTotal = response.total;
+        this.repos = response.repos;
+        this.hasRepos = this.checkRepos();
+      }
+    );
+  }
+
+  ngOnDestroy() {
+    if (typeof this.reposSub !== 'undefined') {
+      this.reposSub.unsubscribe();
+    }
+  }
+
+  ngOnInit() {
+    this.reposSub = this.newSearchSubscription();
+  }
+
   onScroll() {
+    //Triggered by Infinite Scroll
     this.getMoreRepos();
   }
 }

--- a/src/app/components/explore-code/search-results/search-results.template.html
+++ b/src/app/components/explore-code/search-results/search-results.template.html
@@ -1,35 +1,39 @@
-<repos-search></repos-search>
-<div *ngIf="hasRepos" class="repos-container">
-  <p class="repos-count">
-    {{ repos.length }} Featured {{ "Projects" | pluralize : repos.length }}
-  </p>
-  <ul class="repos-list usa-unstyled-list"
-    infinite-scroll
-    [infiniteScrollDistance]="2"
-    [infiniteScrollThrottle]="500"
-    (scrolled)="onScroll()">
-    <li *ngFor="let repo of repos" class="repo">
-      <a routerLink="/explore-code/repos/{{repo.repoID}}">
-        <h3 class="repo-name">{{ repo.name }}</h3>
-        <p class="repo-description">
-          {{ repo.description | truncate : 200 }}
-        </p>
-        <ul class="usa-unstyled-list repo-features">
-          <li *ngFor="let language of repo.codeLanguage" class="language">
-            <i class="devicons devicons-{{language.language | lowercase | languageIcon }}"></i>
-            <span>{{ language.language }}</span>
-          </li>
-          <li>
-            <i class="fa fa-code"></i><span>Open Source</span>
-          </li>
-        </ul>
-      </a>
-    </li>
-  </ul>
-</div>
+<div class="search-results-content">
+  <div class="usa-grid">
+    <repos-search [queryValue]="query"></repos-search>
+    <div *ngIf="hasRepos" class="repos-container">
+      <p class="repos-count">
+        {{ repos.length }} Featured {{ "Projects" | pluralize : repos.length }}
+      </p>
+      <ul class="repos-list usa-unstyled-list"
+        infinite-scroll
+        [infiniteScrollDistance]="2"
+        [infiniteScrollThrottle]="500"
+        (scrolled)="onScroll()">
+        <li *ngFor="let repo of repos" class="repo">
+          <a routerLink="/explore-code/repos/{{repo.repoID}}">
+            <h3 class="repo-name">{{ repo.name }}</h3>
+            <p class="repo-description">
+              {{ repo.description | truncate : 200 }}
+            </p>
+            <ul class="usa-unstyled-list repo-features">
+              <li *ngFor="let language of repo.codeLanguage" class="language">
+                <i class="devicons devicons-{{language.language | lowercase | languageIcon }}"></i>
+                <span>{{ language.language }}</span>
+              </li>
+              <li>
+                <i class="fa fa-code"></i><span>Open Source</span>
+              </li>
+            </ul>
+          </a>
+        </li>
+      </ul>
+    </div>
 
-<div *ngIf="!hasRepos">
-  <p>
-    No repositories found.
-  </p>
+    <div *ngIf="!hasRepos">
+      <p>
+        No repositories found.
+      </p>
+    </div>
+  </div>
 </div>

--- a/src/app/components/repos-search/repos-search.component.spec.ts
+++ b/src/app/components/repos-search/repos-search.component.spec.ts
@@ -38,17 +38,6 @@ describe('ReposSearchComponent', () => {
     this.reposSearchComponent = this.fixture.componentInstance;
   });
 
-  describe('navigateToResults', () => {
-    it('should navigate to results page if not there already',
-      inject([Router], router => {
-      spyOn(router, 'navigateByUrl');
-
-      this.reposSearchComponent.navigateToResults();
-
-      expect(router.navigateByUrl).toHaveBeenCalled();
-    }));
-  });
-
   describe('onSubmit', () => {
     it('should call the search function', () => {
       spyOn(this.reposSearchComponent, 'search');
@@ -60,39 +49,13 @@ describe('ReposSearchComponent', () => {
   });
 
   describe('search', () => {
-    it('should call the search service',
-      inject([SearchService], searchService => {
-      spyOn(searchService, 'setSearchResults');
-      spyOn(this.reposSearchComponent, 'navigateToResults');
+    it('should navigate to results page',
+      inject([Router], router => {
+        let query = 'GSA';
+        spyOn(router, 'navigateByUrl');
+        this.reposSearchComponent.search('GSA');
 
-      spyOn(searchService, 'search').and.callFake(function(start, size, query) {
-        return Observable.of({ response: 'success'});
-      });
-
-      this.reposSearchComponent.search('GSA');
-      expect(searchService.search).toHaveBeenCalledWith(0, 10, 'GSA');
-    }));
-
-    it('should call the navigateToResults function',
-      inject([SearchService], searchService => {
-      spyOn(searchService, 'setSearchResults');
-      spyOn(this.reposSearchComponent, 'navigateToResults');
-
-      spyOn(searchService, 'search').and.callThrough();
-
-      this.reposSearchComponent.search('GSA');
-      expect(this.reposSearchComponent.navigateToResults).toHaveBeenCalled();
-    }));
-
-    it('should call the setSearchResults function in the SearchService',
-      inject([SearchService], searchService => {
-      spyOn(searchService, 'setSearchResults');
-      spyOn(this.reposSearchComponent, 'navigateToResults');
-
-      spyOn(searchService, 'search').and.callThrough();
-
-      this.reposSearchComponent.search('GSA');
-      expect(searchService.setSearchResults).toHaveBeenCalledWith(searchService.getResult(), 3);
+        expect(router.navigateByUrl).toHaveBeenCalledWith('/search?q=' + query);
     }));
   });
 });

--- a/src/app/components/repos-search/repos-search.component.ts
+++ b/src/app/components/repos-search/repos-search.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import {
   FormsModule,
   ReactiveFormsModule,
@@ -12,10 +12,13 @@ import { SearchService } from '../../services/search';
 
 @Component({
   selector: 'repos-search',
-  template: require('./repos-search.template.html')
+  template: require('./repos-search.template.html'),
+  styles: [require('./repos-search.style.scss')],
 })
 
 export class ReposSearchComponent {
+  @Input() queryValue: string;
+
   constructor(
     public formBuilder: FormBuilder,
     private searchService: SearchService,
@@ -24,15 +27,9 @@ export class ReposSearchComponent {
 
   searchForm: FormGroup;
 
-  navigateToResults() {
-    if (this.router.url != '/explore-code/results') {
-      this.router.navigateByUrl('/explore-code/results');
-    }
-  }
-
   ngOnInit() {
-      this.searchForm = this.formBuilder.group({
-        query: [''],
+    this.searchForm = this.formBuilder.group({
+      query: [''],
     });
   }
 
@@ -41,18 +38,6 @@ export class ReposSearchComponent {
   }
 
   search(query: string) {
-    this.searchService.search(0, 10, query).subscribe(
-      result => {
-        if (result) {
-          this.searchService.setSearchResults(result['repos'], result['total']);
-          this.navigateToResults();
-        } else {
-          console.log("No Repos Found");
-        }
-      },
-      error => {
-        console.log(error)
-      }
-    );
+    this.router.navigateByUrl('/search?q=' + query);
   }
 }

--- a/src/app/components/repos-search/repos-search.style.scss
+++ b/src/app/components/repos-search/repos-search.style.scss
@@ -1,0 +1,24 @@
+@import '../../../styles/base/all';
+
+input {
+  @include span-columns(9);
+  margin-top: 0;
+
+  &[type="submit"] {
+    @include span-columns(3);
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+input,
+label {
+  max-width: none;
+}
+
+label {
+  height: 0px;
+  overflow: none;
+  text-align: left;
+  text-indent: -9999px;
+}

--- a/src/app/components/repos-search/repos-search.template.html
+++ b/src/app/components/repos-search/repos-search.template.html
@@ -1,4 +1,5 @@
  <form [formGroup]="searchForm" (ngSubmit)="onSubmit(searchForm.value)">
   <label for="searchQuery">Query</label>
-  <input id="searchQuery" type="text" required class="form-control" [formControl]="searchForm.controls['query']"/>
+  <input id="searchQuery" type="text" required class="form-control" value="{{queryValue}}" [formControl]="searchForm.controls['query']" placeholder="Search Code.gov"/>
+  <input type="submit" value="Search" />
 </form>

--- a/src/app/routes/explore-code/explore-code.routes.ts
+++ b/src/app/routes/explore-code/explore-code.routes.ts
@@ -30,8 +30,7 @@ export const EXPLORE_CODE_ROUTES: Routes = [
         children: [
           { path: ':id', component: RepoComponent }
         ]
-      },
-      { path: 'results', component: SearchResultsComponent }
+      }
     ]
   }
 ];

--- a/src/app/services/search/search.service.spec.ts
+++ b/src/app/services/search/search.service.spec.ts
@@ -7,6 +7,7 @@ import {
   Response,
   XHRBackend
 } from '@angular/http';
+import { Observable } from 'rxjs/Rx';
 
 import { SearchService } from './search.service';
 
@@ -14,17 +15,24 @@ describe('SearchService', () => {
   let service: SearchService;
   let backend: XHRBackend;
   let defaultOptions: BaseRequestOptions;
-  beforeEach(() => { service = new SearchService(new Http(backend, defaultOptions)); });
+  const http = new Http(backend, defaultOptions);
 
-  describe('checkRepos', () => {
-    it('returns true if repos is greater than 0', () => {
-      spyOn(service, 'getRepos').and.returnValue([1,2,3]);
+  beforeEach(() => { service = new SearchService(http); });
 
-      expect(service.checkRepos()).toBe(true);
-    });
-
+  describe('search', () => {
     it('returns false if repos is less than 1', () => {
-      expect(service.checkRepos()).toBe(false);
+      let query = 'GSA';
+      let from = 0;
+      let size = 15;
+      let queryParams = query + '&from=' + from + '&size=' + size;
+      let queryUrl = API_URL + 'repos?_fulltext=' + queryParams;
+
+      spyOn(http, 'get').and.returnValue(
+        Observable.of({response: 'Success'}
+      ));
+      service.search(from, size, 'GSA');
+
+      expect(http.get).toHaveBeenCalledWith(queryUrl);
     });
   });
 });

--- a/src/app/services/search/search.service.ts
+++ b/src/app/services/search/search.service.ts
@@ -7,7 +7,6 @@ import 'rxjs/add/operator/map';
 @Injectable()
 
 export class SearchService {
-  public hasRepos: boolean = false;
   public query: string;
   private displayedRepos: number;
   private repos: Array<any>;
@@ -17,43 +16,6 @@ export class SearchService {
 
   constructor(private http: Http) {}
 
-  addDisplayedRepos(count) {
-    this.displayedRepos += count;
-  }
-
-  addSearchStart(newStart) {
-    this.searchStart += newStart;
-  }
-
-
-  checkRepos() {
-    if (this.getRepos() != null && this.getRepos().length > 0) {
-      return true;
-    } else {
-      return false;
-    }
-  }
-
-  getDisplayedRepos() {
-    return this.displayedRepos;
-  }
-
-  getSearchStart() {
-    return this.searchStart;
-  }
-
-  getRepos() {
-    return this.repos;
-  }
-
-  getReposCount() {
-    return this.reposCount;
-  }
-
-  getQuery() {
-    return this.query;
-  }
-
   search(from: number, size: number, query: string): Observable<Response> {
     this.query = query;
 
@@ -61,20 +23,9 @@ export class SearchService {
     let queryUrl = API_URL + 'repos' + queryParams;
 
     return this.http.get(queryUrl).map(
-      (res:Response) => res.json());
-  }
-
-  searchResults(): Observable<any> {
-    return this.results;
-  }
-
-  setSearchResults(result, total) {
-    this.repos = result;
-    this.displayedRepos = result.length;
-    this.hasRepos = this.checkRepos();
-    this.reposCount = total;
-    this.searchStart = result.length;
-
-    this.results.next(result);
+      (res:Response) => {
+        return res.json()
+      }
+    );
   }
 }


### PR DESCRIPTION
Converts search functionality to be URL param-based, as opposed to depending on the SearchService.

* Simplify SearchService
* Add Search Route
* Use queryParams to store Search queries
* Add Input to RepoSearchComponent to pass URL query param to it