### PR TITLE
Create Api and Term Services

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -26,23 +26,27 @@ import { AppComponent } from './utils/app-components';
 import { IsDefinedPipe } from './pipes/is-defined';
 import { APP_COMPONENTS } from './utils/app-components';
 import { AgencyService, AGENCIES } from './services/agency';
+import { ApiService } from './services/api';
 import { MobileService } from './services/mobile';
 import { ModalService } from './services/modal';
 import { RepoService } from './services/repo';
 import { SearchService } from './services/search';
 import { SeoService } from './services/seo';
 import { StateService } from './services/state';
+import { TermService } from './services/term';
 
 // Application wide providers
 const APP_PROVIDERS = [
   ...APP_RESOLVER_PROVIDERS,
   AgencyService,
+  ApiService,
   MobileService,
   ModalService,
   RepoService,
   SearchService,
   SeoService,
-  StateService
+  StateService,
+  TermService,
 ];
 
 /**

--- a/src/app/services/api/api.service.ts
+++ b/src/app/services/api/api.service.ts
@@ -1,0 +1,23 @@
+import { Http, Response } from '@angular/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Rx';
+import { Subject } from 'rxjs/Subject';
+import 'rxjs/add/operator/map';
+
+@Injectable()
+
+export class ApiService {
+
+  constructor(private apiHttp: Http) {}
+
+  fetch(endpoint: string, query: string): Observable<Response> {
+
+    let queryUrl = API_URL + endpoint + '?' + query;
+
+    return this.apiHttp.get(queryUrl).map(
+      (res:Response) => {
+        return res.json()
+      }
+    );
+  }
+}

--- a/src/app/services/api/index.ts
+++ b/src/app/services/api/index.ts
@@ -1,0 +1,1 @@
+export * from './api.service';

--- a/src/app/services/term/index.ts
+++ b/src/app/services/term/index.ts
@@ -1,0 +1,1 @@
+export * from './term.service';

--- a/src/app/services/term/term.service.ts
+++ b/src/app/services/term/term.service.ts
@@ -1,0 +1,20 @@
+import { Http, Response } from '@angular/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Rx';
+import { Subject } from 'rxjs/Subject';
+import 'rxjs/add/operator/map';
+
+import { ApiService } from '../api';
+
+@Injectable()
+
+export class TermService extends ApiService {
+
+  constructor(private http: Http) {
+    super(http);
+  }
+
+  getTerms(query) {
+    return super.fetch('terms', query);
+  }
+}


### PR DESCRIPTION
Creates an abstracted ApiService for fetching data from the Code.gov API and a TermService for hitting the `/terms` endpoint with a query.

* Create abstracted ApiService for generalized API calls
* Create TermService that extends the ApiService for calls to the `/terms` endpoint