### PR TITLE
Improve social graph meta tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@angularclass/conventions-loader": "^1.0.2",
     "@angularclass/hmr": "~1.2.0",
     "@angularclass/hmr-loader": "~3.0.2",
+    "@ngx-meta/core": "^0.4.0-rc.2",
     "@types/jasmine": "^2.5.53",
     "@types/jasminewd2": "^2.0.2",
     "angulartics2": "1.4.3",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -13,6 +13,8 @@ import { Angulartics2Module, Angulartics2GoogleTagManager } from 'angulartics2';
 import { Ng2PageScrollModule } from 'ng2-page-scroll';
 import { Ng2SimplePageScrollModule } from 'ng2-simple-page-scroll';
 
+import { MetaModule } from '@ngx-meta/core';
+
 /*
  * Platform and Environment providers/directives/pipes
  */
@@ -60,7 +62,8 @@ const APP_PROVIDERS = [
     HttpModule,
     RouterModule.forRoot(ROUTES, { useHash: true }),
     Ng2PageScrollModule.forRoot(),
-    Ng2SimplePageScrollModule.forRoot()
+    Ng2SimplePageScrollModule.forRoot(),
+    MetaModule.forRoot()
   ],
   declarations: [
     APP_COMPONENTS,

--- a/src/app/components/explore-code/agencies/agencies.component.ts
+++ b/src/app/components/explore-code/agencies/agencies.component.ts
@@ -10,9 +10,7 @@ import { MobileService } from '../../../services/mobile';
 
 export class AgenciesComponent {
 
-  constructor(
-    private mobileService: MobileService
-  ) {
+  constructor(private mobileService: MobileService) {
     this.mobileService.hideMenu();
   }
 }

--- a/src/app/components/explore-code/agencies/agencies.component.ts
+++ b/src/app/components/explore-code/agencies/agencies.component.ts
@@ -10,7 +10,9 @@ import { MobileService } from '../../../services/mobile';
 
 export class AgenciesComponent {
 
-  constructor(private mobileService: MobileService) {
+  constructor(
+    private mobileService: MobileService
+  ) {
     this.mobileService.hideMenu();
   }
 }

--- a/src/app/components/explore-code/agency/agency.component.spec.ts
+++ b/src/app/components/explore-code/agency/agency.component.spec.ts
@@ -12,6 +12,7 @@ import { PluralizePipe } from '../../../pipes/pluralize';
 import { ReposService } from '../../../services/repos';
 import { SeoService } from '../../../services/seo';
 import { TruncatePipe } from '../../../pipes/truncate';
+import { MetaModule } from '@ngx-meta/core';
 
 class MockActivatedRoute extends ActivatedRoute {
   constructor() {
@@ -32,7 +33,8 @@ describe('AgencyComponent', () => {
       ],
       imports: [
         HttpModule,
-        RouterModule
+        RouterModule,
+        MetaModule.forRoot()
       ],
       providers: [
         AgencyService,

--- a/src/app/components/explore-code/agency/agency.component.ts
+++ b/src/app/components/explore-code/agency/agency.component.ts
@@ -7,6 +7,7 @@ import { LanguageIconPipe } from '../../../pipes/language-icon';
 import { PluralizePipe } from '../../../pipes/pluralize';
 import { SeoService } from '../../../services/seo';
 import { TruncatePipe } from '../../../pipes/truncate';
+import { MetaService } from '@ngx-meta/core';
 
 @Component({
   selector: 'agency',
@@ -25,7 +26,8 @@ export class AgencyComponent implements OnInit, OnDestroy {
     private agencyService: AgencyService,
     private route: ActivatedRoute,
     private reposService: ReposService,
-    private seoService: SeoService
+    private seoService: SeoService,
+    private readonly meta: MetaService
   ) {}
 
   ngOnDestroy() {
@@ -46,6 +48,12 @@ export class AgencyComponent implements OnInit, OnDestroy {
       this.seoService.setTitle(this.agency.name, true);
       this.seoService.setMetaDescription('Browse code from the ' + this.agency.name);
       this.seoService.setMetaRobots('Index, Follow');
+
+      this.meta.setTag('twitter:card', 'summary');
+      this.meta.setTag('twitter:site', '@codedotgov');
+      this.meta.setTag('twitter:title', `code.gov/${this.agency.name}`);
+      this.meta.setTag('twitter:description', 'Browse code from the ' + this.agency.name);
+      this.meta.setTag('twitter:image', 'https://code.gov/assets/img/og.jpg');
     });
   }
 

--- a/src/app/components/explore-code/repo/repo.component.spec.ts
+++ b/src/app/components/explore-code/repo/repo.component.spec.ts
@@ -20,6 +20,7 @@ import { ModalComponent } from './../../modal/modal.component';
 import { ActivityListComponent } from './../activity-list/activity-list.component';
 import { ModalService } from './../../../services/modal/modal.service';
 import { IsDefinedPipe } from './../../../pipes/is-defined/is-defined.pipe';
+import { MetaModule, MetaService } from '@ngx-meta/core';
 
 // set test repository id used throughout to Dept of Veterans Affairs
 let id = '33202667';
@@ -57,7 +58,8 @@ describe('RepoComponent', () => {
         // This hack is needed because there is a routerLink in the template
         RouterTestingModule.withRoutes([
          { path: 'explore-code/agencies/:id', component: DummyRoutingComponent }
-        ])
+        ]),
+        MetaModule.forRoot()
       ],
       declarations: [
         ExternalLinkDirective,
@@ -102,14 +104,14 @@ describe('RepoComponent', () => {
   }));
 
   it('should NOT initialize repo property if id property is bogus',
-    inject([AgencyService, ReposService],
-      (agencyService, reposService)  => {
+    inject([AgencyService, ReposService, MetaService],
+      (agencyService, reposService, metaService)  => {
     let agency = { id: 'VA', name: 'Department of Veterans Affairs' };
     spyOn(agencyService, 'getAgency').and.returnValue(agency);
     let repos = undefined;
     spyOn(reposService, 'getJsonFile').and.returnValue(Observable.of(repos));
     // instantiate a new RepoComponent so that ngOnInit() doesn't get called
-    let newRepoComponent = new RepoComponent(null, agencyService, reposService, null);
+    let newRepoComponent = new RepoComponent(null, agencyService, reposService, null, metaService);
 
     // call getRepo() that invokes reposService.getJsonFile()
     newRepoComponent.getRepo('');

--- a/src/app/components/explore-code/repo/repo.component.ts
+++ b/src/app/components/explore-code/repo/repo.component.ts
@@ -5,6 +5,7 @@ import { AgencyService, Agency } from '../../../services/agency';
 import { ExternalLinkDirective } from '../../../directives/external-link';
 import { ReposService } from '../../../services/repos';
 import { SeoService } from '../../../services/seo';
+import { MetaService } from '@ngx-meta/core';
 
 @Component({
   selector: 'repo',
@@ -22,7 +23,8 @@ export class RepoComponent implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private agencyService: AgencyService,
     private reposService: ReposService,
-    private seoService: SeoService
+    private seoService: SeoService,
+    private readonly meta: MetaService
   ) {}
 
   ngOnInit() {
@@ -48,6 +50,11 @@ export class RepoComponent implements OnInit, OnDestroy {
           this.seoService.setTitle(this.repo.name, true);
           this.seoService.setMetaDescription(this.repo.description);
           this.seoService.setMetaRobots('Index, Follow');
+          this.meta.setTag('twitter:card', 'summary');
+          this.meta.setTag('twitter:site', '@codedotgov');
+          this.meta.setTag('twitter:title', `code.gov/${this.repo.name}`);
+          this.meta.setTag('twitter:description', this.repo.description);
+          this.meta.setTag('twitter:image', 'https://code.gov/assets/img/og.jpg');
         } else {
           console.log('Error. Source code repositories not found');
         }

--- a/src/app/components/home/home.component.spec.ts
+++ b/src/app/components/home/home.component.spec.ts
@@ -12,6 +12,7 @@ import { ModalComponent } from '../modal';
 import { ModalService } from '../../services/modal';
 import { SeoService } from '../../services/seo';
 import { StateService } from '../../services/state';
+import { MetaModule } from '@ngx-meta/core';
 
 describe('HomeComponent', () => {
 
@@ -25,7 +26,8 @@ describe('HomeComponent', () => {
       ],
       imports: [
         Angulartics2Module.forRoot(),
-        RouterModule.forRoot([])
+        RouterModule.forRoot([]),
+        MetaModule.forRoot()
       ],
       providers: [
         Angulartics2,

--- a/src/app/services/seo/seo.service.ts
+++ b/src/app/services/seo/seo.service.ts
@@ -1,48 +1,38 @@
 import { Inject, Injectable, RendererFactory2, ViewEncapsulation } from '@angular/core';
-import { DOCUMENT, Title } from '@angular/platform-browser';
+import { DOCUMENT } from '@angular/platform-browser';
+import { MetaService } from '@ngx-meta/core';
 
 @Injectable()
 
 export class SeoService {
 
   private baseTitle: string;
-  private titleService: Title;
   private headElement: HTMLElement;
-  private metaDescription: HTMLElement;
   private robots: HTMLElement;
   private DOM: any;
   private rendererFactory: RendererFactory2;
 
   constructor(
-    titleService: Title,
     @Inject(DOCUMENT) document,
-    @Inject(RendererFactory2) rendererFactory
+    @Inject(RendererFactory2) rendererFactory,
+    private readonly meta: MetaService
   ) {
     this.baseTitle = '· Code.gov';
-    this.titleService = titleService;
     this.rendererFactory = rendererFactory;
     this.DOM = document;
     this.headElement = this.DOM.head;
-    this.metaDescription = this.getOrCreateMetaElement('description');
     this.robots = this.getOrCreateMetaElement('robots');
-  }
-
-  public getTitle(): string {
-    return this.titleService.getTitle();
   }
 
   public setTitle(newTitle: string, baseTitle = false) {
     if (baseTitle === true)
       newTitle += ' · Code.gov';
-    this.titleService.setTitle(newTitle);
-  }
 
-  public getMetaDescription(): string {
-    return this.metaDescription.getAttribute('content');
+    this.meta.setTitle(newTitle);
   }
 
   public setMetaDescription(description: string) {
-    this.metaDescription.setAttribute('content', description);
+    this.meta.setTag('description', description);
   }
 
   public getMetaRobots(): string {

--- a/src/index.html
+++ b/src/index.html
@@ -8,6 +8,7 @@
   <title>Code.gov</title>
   <meta name="description" content="Code.gov is a platform designed to improve access to the federal government’s custom-developed software.">
 
+  <meta property="og:image" content="assets/img/og.jpg">
   <meta property="og:image:url" content="assets/img/og.jpg">
   <meta property="og:image:type" content="image/jpeg">
   <meta property="og:image:width" content="1200">

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,6 +80,12 @@
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@angularclass/hmr/-/hmr-1.2.2.tgz#46a18f89a1e94d05c268b83c9480e005f73fc265"
 
+"@ngx-meta/core@^0.4.0-rc.2":
+  version "0.4.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@ngx-meta/core/-/core-0.4.0-rc.2.tgz#1bd793103a1a5d463ba773db9f56d3eb8575c2c8"
+  dependencies:
+    tslib "^1.7.0"
+
 "@types/core-js@^0.9.34":
   version "0.9.42"
   resolved "https://registry.yarnpkg.com/@types/core-js/-/core-js-0.9.42.tgz#dd6da92cd7d5ab5ca0b4477524537c3e633b6bce"
@@ -7078,7 +7084,7 @@ tsconfig@^5.0.2:
     strip-bom "^2.0.0"
     strip-json-comments "^2.0.0"
 
-tslib@^1.7.1:
+tslib@^1.7.0, tslib@^1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.7.1.tgz#bc8004164691923a79fe8378bbeb3da2017538ec"
 


### PR DESCRIPTION
### Why?

* In order to make the site easily shareable, we should improve the open graph tags we use across the site.

## What Changed?

* Pulled in `ngx-meta` to handle meta tags
* Refactored existing services to use the `ngx-meta` one
* Added additional open graph and twitter card tags to the repo and agency component