### PR TITLE
Change settings for the production build and also minify CSS.

### DIFF
--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -1,5 +1,5 @@
 const commonConfig = require('./webpack.common.js');
-const ENV = process.env.NODE_ENV = process.env.ENV = 'staging';
+const ENV = process.env.NODE_ENV = process.env.ENV = 'production';
 
 module.exports = function (env) {
   return commonConfig({ env: ENV });

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "bourbon": "^4.3.4",
     "bourbon-neat": "^2.0.0",
     "core-js": "^2.4.1",
+    "cssnano": "^3.10.0",
     "extract-text-webpack-plugin": "^3.0.0",
     "http-server": "^0.9.0",
     "ie-shim": "^0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1613,7 +1613,7 @@ cssesc@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-0.1.0.tgz#c814903e45623371a0477b40109aaafbeeaddbb4"
 
-"cssnano@>=2.6.1 <4":
+"cssnano@>=2.6.1 <4", cssnano@^3.10.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-3.10.0.tgz#4f38f6cea2b9b17fa01490f23f1dc68ea65c1c38"
   dependencies:


### PR DESCRIPTION
### Why?

* Running Angular in production should create a faster site
* Minified CSS should reduce load times for guests

### What Changed?

* Set `ENV` to `production` on the production build
* Minify the CSS that gets output by Critical