### PR TITLE
Hide autocomplete on blur, escape, or enter.

### DIFF
--- a/src/app/components/autocomplete/autocomplete.component.ts
+++ b/src/app/components/autocomplete/autocomplete.component.ts
@@ -12,7 +12,6 @@ import { TermService } from '../../services/term';
 })
 
 export class AutocompleteComponent {
-  @Input() query: string;
   public results: any[] = [];
   private subscription: Subscription;
 

--- a/src/app/components/home/home.template.html
+++ b/src/app/components/home/home.template.html
@@ -6,7 +6,7 @@
         <p>
           Unlock the tremendous potential of the Federal Government’s software.
         </p>
-        <repos-search></repos-search>
+        <repos-search autofocus=true></repos-search>
       </div>
     </div>
     <banner-art></banner-art>

--- a/src/app/components/repos-search/repos-search.component.ts
+++ b/src/app/components/repos-search/repos-search.component.ts
@@ -1,8 +1,10 @@
 import {
   Component,
+  ElementRef,
   EventEmitter,
   Input,
-  Output
+  Output,
+  ViewChild,
 } from '@angular/core';
 import {
   FormsModule,
@@ -23,7 +25,9 @@ import { TermService } from '../../services/term';
 })
 
 export class ReposSearchComponent {
-  @Input() queryValue: string;
+  @Input() queryValue = '';
+  @Input() autofocus = false;
+  @ViewChild('query') queryElement: ElementRef;
   searchForm: FormGroup;
   public autocompleteVisible: boolean = false;
   public queryInputValue: string = '';
@@ -36,18 +40,31 @@ export class ReposSearchComponent {
   ) {}
 
   hasQuery(): boolean {
-    return !!this.queryInputValue;
+    return this.queryInputValue.length > 0;
   }
 
   ngOnInit() {
     this.searchForm = this.formBuilder.group({
       query: [''],
     });
+
+    this.termService.search(this.queryValue);
+    this.queryInputValue = this.queryValue;
+  }
+
+  ngAfterViewInit() {
+    if (this.autofocus) {
+      this.queryElement.nativeElement.focus();
+    }
   }
 
   onKey(event: any) {
     this.queryInputValue = event.target.value;
     this.termService.search(this.queryInputValue);
+
+    if (event.code === 'Escape' || event.code === 'Enter') {
+      event.target.blur();
+    }
   }
 
   onSubmit(form: any): void {
@@ -58,7 +75,11 @@ export class ReposSearchComponent {
     this.router.navigateByUrl('/search?q=' + query);
   }
 
-  toggleAutocomplete(autocompleteVisible: boolean) {
-    this.autocompleteVisible = autocompleteVisible;
+  showAutocomplete() {
+    setTimeout(() => this.autocompleteVisible = true, 50);
+  }
+
+  hideAutocomplete() {
+    setTimeout(() => this.autocompleteVisible = false, 50);
   }
 }

--- a/src/app/components/repos-search/repos-search.template.html
+++ b/src/app/components/repos-search/repos-search.template.html
@@ -1,8 +1,20 @@
 <form class="search-form" [formGroup]="searchForm" (ngSubmit)="onSubmit(searchForm.value)">
   <label for="searchQuery">Query</label>
-  <input id="searchQuery" type="text" required class="form-control" value="{{queryValue}}" [formControl]="searchForm.controls['query']" (focus)="this.toggleAutocomplete(true)" (keyup)="onKey($event)" placeholder="Search Code.gov" autofocus autocomplete="off"/>
+  <input
+      #query
+      id="searchQuery"
+      type="text"
+      required
+      class="form-control"
+      value="{{queryValue}}"
+      [formControl]="searchForm.controls['query']"
+      (focus)="showAutocomplete()"
+      (blur)="hideAutocomplete()"
+      (keyup)="onKey($event)"
+      placeholder="Search Code.gov"
+      autocomplete="off" />
   <input type="submit" value="Search" />
 </form>
 <div *ngIf="hasQuery() && autocompleteVisible" class="autocomplete-container">
-  <autocomplete [query]='queryInputValue'></autocomplete>
+  <autocomplete></autocomplete>
 </div>

--- a/src/app/services/term/elasticsearch-term.service.ts
+++ b/src/app/services/term/elasticsearch-term.service.ts
@@ -1,7 +1,7 @@
 import { Http } from '@angular/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Rx';
-import { Subject } from 'rxjs/Subject';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 import { ApiService } from '../api';
 import { AgencyService } from '../agency';
@@ -12,7 +12,7 @@ import { TermService } from './term.service';
 
 export class ElasticsearchTermService extends ApiService implements TermService {
   termResultsReturned$: Observable<Array<any>>;
-  private termResultsReturnedSource = new Subject<Array<any>>();
+  private termResultsReturnedSource = new BehaviorSubject<Array<any>>([]);
 
   constructor(
     private http: Http,

--- a/src/app/services/term/lunr-term.service.ts
+++ b/src/app/services/term/lunr-term.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Rx';
-import { Subject } from 'rxjs/Subject';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import 'rxjs/add/operator/map';
 import * as lunr from 'lunr';
 
@@ -13,7 +13,7 @@ export class LunrTermService implements TermService {
   termResultsReturned$: Observable<Array<any>>;
   private idx: any;
   private reposByRef: Object = {};
-  private termResultsReturnedSource = new Subject<Array<any>>();
+  private termResultsReturnedSource = new BehaviorSubject<Array<any>>([]);
 
   constructor() {
     const reposByRef = this.reposByRef;


### PR DESCRIPTION
### Why?

* The autocomplete suggestions would often get in the way, there was no way to close them.

### What Changed?

* We now hide the autocomplete on blur. The slight delay allows clicking on an item and navigating to it.
* The enter key and escape key now also trigger the field to blur.
* The field no longer gains autofocus on the search page, but still does on the home page