### PR TITLE
Small tweaks to the banner on the homepage.

### DIFF
--- a/src/app/components/home/banner-art/banner-art.style.scss
+++ b/src/app/components/home/banner-art/banner-art.style.scss
@@ -94,7 +94,7 @@
     font-size: 1.1em;
   }
 
-  .dolla {
+  .prompt {
     margin-right: 0.5em;
   }
 

--- a/src/app/components/home/banner-art/banner-art.template.html
+++ b/src/app/components/home/banner-art/banner-art.template.html
@@ -6,11 +6,11 @@
   </div>
   <div class="content">
     <p>
-      <span class="dolla">$</span>
-      Want to contribute to <a href="./">Code.gov</a>?
+      <span class="prompt">&gt;</span>
+      Want to improve <a href="https://github.com/presidential-innovation-fellows/code-gov-web">Code.gov</a>?
     </p>
     <p class="second-line">
-      <span class="dolla">$</span>
+      <span class="prompt">&gt;</span>
       Visit our <a href="https://github.com/presidential-innovation-fellows/code-gov-web" target="_blank" rel="noopener">project page</a> or git clone git@github.com:presidential-innovation-fellows/code-gov-web.git
       <span class="cursor">&#x275a;</span>
     </p>


### PR DESCRIPTION
### Why?

* The `$` prompt was a little confusing, some felt we were asking for donations.

### What Changed?

* Changed the prompt to `>`
* Changed phrasing from "want to contribute to Code.gov" to "want to improve Code.gov"
* Changed the link so we weren't redirecting to the same page.

Before
<img width="644" alt="screen shot 2017-09-18 at 3 12 04 pm" src="https://user-images.githubusercontent.com/751175/30559775-c4a312c2-9c83-11e7-8c9a-7ac7f9bc3512.png">

After
<img width="646" alt="screen shot 2017-09-18 at 3 09 17 pm" src="https://user-images.githubusercontent.com/751175/30559749-ae2c722c-9c83-11e7-85e0-e3a9b1829542.png">
