### PR TITLE
Sort repositories on the agency in alphabetical order.

### DIFF
--- a/src/app/components/explore-code/agency/agency.component.spec.ts
+++ b/src/app/components/explore-code/agency/agency.component.spec.ts
@@ -87,4 +87,68 @@ describe('AgencyComponent', () => {
       expect(this.agencyComponent.eventSub.unsubscribe).toHaveBeenCalled();
     });
   });
+
+  describe('agencyRepos', () => {
+    it('should sort the repositories returned.', () => {
+      this.fixture.detectChanges();
+      spyOn(this.agencyComponent.reposService, 'getJsonFile').and.returnValue(
+        Observable.of({
+          releases: {
+            'DOL/test': {
+              agency: 'DOL',
+              id: 'DOL/test',
+              name: 'test',
+              permissions: {
+                usageType: 'openSource',
+              },
+            },
+            'DOL/trial': {
+              agency: 'DOL',
+              id: 'DOL/trial',
+              name: 'trial',
+              permissions: {
+                usageType: 'openSource',
+              },
+            },
+            'DOL/example': {
+              agency: 'DOL',
+              id: 'DOL/example',
+              name: 'example',
+              permissions: {
+                usageType: 'openSource',
+              },
+            }
+          }
+        })
+      )
+
+      this.agencyComponent.agencyRepos();
+      expect(this.agencyComponent.allRepos).toEqual([
+        {
+          agency: 'DOL',
+          id: 'DOL/example',
+          name: 'example',
+          permissions: {
+            usageType: 'openSource',
+          },
+        },
+        {
+          agency: 'DOL',
+          id: 'DOL/test',
+          name: 'test',
+          permissions: {
+            usageType: 'openSource',
+          },
+        },
+        {
+          agency: 'DOL',
+          id: 'DOL/trial',
+          name: 'trial',
+          permissions: {
+            usageType: 'openSource',
+          },
+        },
+      ]);
+    });
+  });
 });

--- a/src/app/components/explore-code/agency/agency.component.ts
+++ b/src/app/components/explore-code/agency/agency.component.ts
@@ -74,7 +74,8 @@ export class AgencyComponent implements OnInit, OnDestroy {
       subscribe((result) => {
         if (result && result.releases !== null && typeof result.releases === 'object') {
           this.allRepos = Object.values(result.releases).filter(repo => this.filterByAgency(repo))
-            .filter(repo => repo.permissions.usageType === 'openSource' || repo.permissions.usageType === 'governmentWideReuse');
+            .filter(repo => repo.permissions.usageType === 'openSource' || repo.permissions.usageType === 'governmentWideReuse')
+            .sort((a, b) => a.name.toLowerCase() < b.name.toLowerCase() ? -1 : a.name.toLowerCase() === b.name.toLowerCase() ? 0 : 1);
           this.repos = this.allRepos.slice(0, this.repos.length || this.pageSize);
           this.currentIndex = this.repos.length || this.pageSize;
           this.hasRepos = this.checkRepos(this.repos);

--- a/src/app/components/four-oh-four/four-oh-four.component.spec.ts
+++ b/src/app/components/four-oh-four/four-oh-four.component.spec.ts
@@ -1,0 +1,74 @@
+import { APP_BASE_HREF } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { TestBed, ComponentFixture, inject } from '@angular/core/testing';
+
+import { FourOhFourComponent } from './four-oh-four.component';
+import { StateService } from '../../services/state';
+
+class MockRouter {
+  url: string;
+  constructor() {
+    this.url = '/explore-code/';
+  }
+
+  navigateByUrl() {
+    return true;
+  }
+}
+
+describe('FourOhFourComponent', () => {
+
+  describe('component logic', () => {
+    let fixture: ComponentFixture<FourOhFourComponent>;
+    let component: FourOhFourComponent;
+    let mockRouter: any;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          RouterModule.forRoot([]),
+        ],
+        declarations: [ FourOhFourComponent ],
+        providers: [
+          StateService,
+          { provide: APP_BASE_HREF, useValue: '/' },
+        ]
+      });
+      fixture = TestBed.createComponent(FourOhFourComponent);
+      component = fixture.componentInstance;
+    });
+
+    it('should have defined FourOhFourComponent instance', () => {
+      fixture.detectChanges();
+      expect(component).toBeDefined();
+    });
+  });
+
+  describe('component template', () => {
+    let fixture: ComponentFixture<FourOhFourComponent>;
+    let component: FourOhFourComponent;
+    beforeEach(() => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [
+          RouterModule.forRoot([]),
+        ],
+        declarations: [ FourOhFourComponent ],
+        providers: [
+          StateService,
+          { provide: APP_BASE_HREF, useValue: '/' },
+        ]
+      });
+
+      fixture = TestBed.createComponent(FourOhFourComponent);
+      component = fixture.componentInstance;
+    });
+
+    it('should have an element with four-oh-four-container as a class', () => {
+      fixture.detectChanges();
+      let container = fixture.nativeElement.querySelector('.four-oh-four-container');
+
+      expect(container).toBeDefined();
+    });
+  });
+});

--- a/src/app/components/home/banner-art/banner-art.component.spec.ts
+++ b/src/app/components/home/banner-art/banner-art.component.spec.ts
@@ -1,0 +1,64 @@
+import { APP_BASE_HREF } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { TestBed, ComponentFixture, inject } from '@angular/core/testing';
+
+import { BannerArtComponent } from './banner-art.component';
+import { StateService } from '../../services/state';
+
+class MockRouter {
+  url: string;
+  constructor() {
+    this.url = '/explore-code/';
+  }
+
+  navigateByUrl() {
+    return true;
+  }
+}
+
+describe('BannerArtComponent', () => {
+
+  describe('component logic', () => {
+    let fixture: ComponentFixture<BannerArtComponent>;
+    let component: BannerArtComponent;
+    let mockRouter: any;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [],
+        declarations: [ BannerArtComponent ],
+        providers: []
+      });
+      fixture = TestBed.createComponent(BannerArtComponent);
+      component = fixture.componentInstance;
+    });
+
+    it('should have defined BannerArtComponent instance', () => {
+      fixture.detectChanges();
+      expect(component).toBeDefined();
+    });
+  });
+
+  describe('component template', () => {
+    let fixture: ComponentFixture<BannerArtComponent>;
+    let component: BannerArtComponent;
+    beforeEach(() => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [],
+        declarations: [ BannerArtComponent ],
+        providers: []
+      });
+
+      fixture = TestBed.createComponent(BannerArtComponent);
+      component = fixture.componentInstance;
+    });
+
+    it('should have an element with artwork as a class', () => {
+      fixture.detectChanges();
+      let artwork = fixture.nativeElement.querySelector('.artwork');
+
+      expect(artwork).toBeDefined();
+    });
+  });
+});

--- a/src/app/components/search-results/search-results.component.spec.ts
+++ b/src/app/components/search-results/search-results.component.spec.ts
@@ -1,0 +1,103 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { APP_BASE_HREF } from '@angular/common';
+import { HttpModule } from '@angular/http';
+import { ActivatedRoute, RouterModule } from '@angular/router';
+import { TestBed, ComponentFixture, inject } from '@angular/core/testing';
+import { Observable } from 'rxjs';
+
+import { SearchResultsComponent } from './search-results.component';
+import { StateService } from '../../services/state';
+import { MobileService } from '../../services/mobile';
+import { LunrSearchService, SearchService } from '../../services/search';
+import { AgenciesIndexService, ReleasesIndexService } from '../../services/indexes';
+
+class MockRouter {
+  url: string;
+  constructor() {
+    this.url = '/search?q=test';
+  }
+
+  navigateByUrl() {
+    return true;
+  }
+}
+
+class MockActivatedRoute extends ActivatedRoute {
+  constructor() {
+    super();
+    this.queryParams = Observable.of({ q: 'test '});
+  }
+}
+
+describe('SearchResultsComponent', () => {
+
+  describe('component logic', () => {
+    let fixture: ComponentFixture<SearchResultsComponent>;
+    let component: SearchResultsComponent;
+    let mockRouter: any;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          RouterModule.forRoot([]),
+          HttpModule,
+        ],
+        declarations: [ SearchResultsComponent ],
+        providers: [
+          StateService,
+          AgenciesIndexService,
+          ReleasesIndexService,
+          { provide: APP_BASE_HREF, useValue: '/' },
+          { provide: SearchService, useClass: LunrSearchService },
+          { provide: ActivatedRoute, useClass: MockActivatedRoute },
+        ],
+        schemas: [
+          CUSTOM_ELEMENTS_SCHEMA,
+        ],
+      });
+      fixture = TestBed.createComponent(SearchResultsComponent);
+      component = fixture.componentInstance;
+    });
+
+    it('should have defined SearchResultsComponent instance', () => {
+      fixture.detectChanges();
+      expect(component).toBeDefined();
+    });
+  });
+
+  describe('component template', () => {
+    let fixture: ComponentFixture<SearchResultsComponent>;
+    let component: SearchResultsComponent;
+    beforeEach(() => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [
+          RouterModule.forRoot([]),
+          HttpModule,
+        ],
+        declarations: [ SearchResultsComponent ],
+        providers: [
+          StateService,
+          AgenciesIndexService,
+          ReleasesIndexService,
+          { provide: APP_BASE_HREF, useValue: '/' },
+          { provide: SearchService, useClass: LunrSearchService },
+          { provide: ActivatedRoute, useClass: MockActivatedRoute },
+        ],
+        schemas: [
+          CUSTOM_ELEMENTS_SCHEMA,
+        ],
+      });
+
+      fixture = TestBed.createComponent(SearchResultsComponent);
+      component = fixture.componentInstance;
+    });
+
+    it('should have an element with search-results-content as a class', () => {
+      fixture.detectChanges();
+      let searchResultsContainer = fixture.nativeElement.querySelector('.search-results-content');
+
+      expect(searchResultsContainer).toBeDefined();
+    });
+  });
+});

--- a/src/app/components/sidebar/sidebar.component.spec.ts
+++ b/src/app/components/sidebar/sidebar.component.spec.ts
@@ -1,0 +1,77 @@
+import { APP_BASE_HREF } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { TestBed, ComponentFixture, inject } from '@angular/core/testing';
+
+import { SidebarComponent } from './sidebar.component';
+import { StateService } from '../../services/state';
+import { MobileService } from '../../services/mobile';
+
+class MockRouter {
+  url: string;
+  constructor() {
+    this.url = '/explore-code/';
+  }
+
+  navigateByUrl() {
+    return true;
+  }
+}
+
+describe('SidebarComponent', () => {
+
+  describe('component logic', () => {
+    let fixture: ComponentFixture<SidebarComponent>;
+    let component: SidebarComponent;
+    let mockRouter: any;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          RouterModule.forRoot([]),
+        ],
+        declarations: [ SidebarComponent ],
+        providers: [
+          MobileService,
+          StateService,
+          { provide: APP_BASE_HREF, useValue: '/' },
+        ]
+      });
+      fixture = TestBed.createComponent(SidebarComponent);
+      component = fixture.componentInstance;
+    });
+
+    it('should have defined SidebarComponent instance', () => {
+      fixture.detectChanges();
+      expect(component).toBeDefined();
+    });
+  });
+
+  describe('component template', () => {
+    let fixture: ComponentFixture<SidebarComponent>;
+    let component: SidebarComponent;
+    beforeEach(() => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [
+          RouterModule.forRoot([]),
+        ],
+        declarations: [ SidebarComponent ],
+        providers: [
+          MobileService,
+          StateService,
+          { provide: APP_BASE_HREF, useValue: '/' },
+        ]
+      });
+
+      fixture = TestBed.createComponent(SidebarComponent);
+      component = fixture.componentInstance;
+    });
+
+    it('should have an element with sidebar as a class', () => {
+      fixture.detectChanges();
+      let sidebar = fixture.nativeElement.querySelector('.sidebar');
+
+      expect(sidebar).toBeDefined();
+    });
+  });
+});

--- a/src/app/components/subnav/subnav.component.spec.ts
+++ b/src/app/components/subnav/subnav.component.spec.ts
@@ -1,0 +1,74 @@
+import { APP_BASE_HREF } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { TestBed, ComponentFixture, inject } from '@angular/core/testing';
+
+import { SubnavComponent } from './subnav.component';
+import { StateService } from '../../services/state';
+
+class MockRouter {
+  url: string;
+  constructor() {
+    this.url = '/explore-code/';
+  }
+
+  navigateByUrl() {
+    return true;
+  }
+}
+
+describe('SubnavComponent', () => {
+
+  describe('component logic', () => {
+    let fixture: ComponentFixture<SubnavComponent>;
+    let component: SubnavComponent;
+    let mockRouter: any;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          RouterModule.forRoot([]),
+        ],
+        declarations: [ SubnavComponent ],
+        providers: [
+          StateService,
+          { provide: APP_BASE_HREF, useValue: '/' },
+        ]
+      });
+      fixture = TestBed.createComponent(SubnavComponent);
+      component = fixture.componentInstance;
+    });
+
+    it('should have defined SubnavComponent instance', () => {
+      fixture.detectChanges();
+      expect(component).toBeDefined();
+    });
+  });
+
+  describe('component template', () => {
+    let fixture: ComponentFixture<SubnavComponent>;
+    let component: SubnavComponent;
+    beforeEach(() => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [
+          RouterModule.forRoot([]),
+        ],
+        declarations: [ SubnavComponent ],
+        providers: [
+          StateService,
+          { provide: APP_BASE_HREF, useValue: '/' },
+        ]
+      });
+
+      fixture = TestBed.createComponent(SubnavComponent);
+      component = fixture.componentInstance;
+    });
+
+    it('should have an element with subnav as a class', () => {
+      fixture.detectChanges();
+      let subnav = fixture.nativeElement.querySelector('.subnav');
+
+      expect(subnav).toBeDefined();
+    });
+  });
+});

--- a/src/app/services/indexes/agencies-index.service.spec.ts
+++ b/src/app/services/indexes/agencies-index.service.spec.ts
@@ -1,0 +1,42 @@
+import {
+  Http,
+  Headers,
+  BaseRequestOptions,
+  RequestOptions,
+  RequestOptionsArgs,
+  Response,
+  XHRBackend
+} from '@angular/http';
+import { Observable, Subject } from 'rxjs/Rx';
+
+import { AgenciesIndexService } from './agencies-index.service';
+
+describe('AgenciesIndexService', () => {
+  let service: AgenciesIndexService;
+  let backend: XHRBackend;
+  let defaultOptions: BaseRequestOptions = new BaseRequestOptions();
+  const http = new Http(backend, defaultOptions);
+
+  beforeEach(() => {
+    spyOn(http, 'get').and.returnValue(
+      Observable.of({
+        json() {
+          return {
+            agencies: []
+          };
+        }
+      }));
+
+    service = new AgenciesIndexService(http);
+  });
+
+  describe('search', () => {
+    it('makes a request to the API', () => {
+      const source = new Subject<any>();
+
+      service.search('GSA', source);
+
+      expect(http.get).toHaveBeenCalledWith('assets/agencies.json');
+    });
+  });
+});


### PR DESCRIPTION
### Why?

* Repositories ought to be sorted in alphabetical order on the agency page.

### What Changed?

* Ran a sort on the repositories for that page doing a comparison of names.

Before
<img width="979" alt="screen shot 2017-09-20 at 3 49 25 pm" src="https://user-images.githubusercontent.com/751175/30664364-668cf7f4-9e1b-11e7-9d83-1129b2df4732.png">

After
<img width="974" alt="screen shot 2017-09-20 at 3 49 18 pm" src="https://user-images.githubusercontent.com/751175/30664369-6b4c4286-9e1b-11e7-94f0-716d627dd4da.png">
