### PR TITLE
Update the margin left to center the search box properly.

### DIFF
--- a/src/app/components/repos-search/repos-search.style.scss
+++ b/src/app/components/repos-search/repos-search.style.scss
@@ -58,4 +58,5 @@ label {
 
 .search-input-container {
   @include grid-column(9);
+  margin-left: 25px;
 }


### PR DESCRIPTION
### Why?

* Centering was off on homepage's search box.

### What Changed?

* Added padding.